### PR TITLE
docs: propose backlog items 030, 040, 050

### DIFF
--- a/product/backlog/030-edit-budget-month-year.md
+++ b/product/backlog/030-edit-budget-month-year.md
@@ -1,0 +1,87 @@
+# Edit an unlocked budget's month and year after creation
+
+- **ID:** 030-edit-budget-month-year
+- **Scope:** full-stack
+- **Size:** M
+
+## Why
+
+If the couple picks the wrong month (or year) when starting a budget, today the
+only fix is to delete the whole draft and rebuild every income, expense, and
+savings row from scratch. That is exactly the kind of avoidable, error-prone
+rework Balance exists to remove. STATE.md flags this gap directly: "There is no
+`PUT /api/budgets/{id}` — month/year is not editable after creation (backlog
+item 030)."
+
+## What
+
+Allow changing the **month and/or year of an UNLOCKED budget** in place,
+keeping all of its line items. A LOCKED budget stays immutable (month/year
+included). The new month/year must still be unique among non-deleted budgets,
+using the same rule that budget creation enforces today. Nothing about the
+lock/unlock flow, transfer calculation, or line items changes — only the
+budget's period.
+
+## Acceptance criteria
+
+- [ ] `PUT /api/budgets/{id}` updates month and/or year of an UNLOCKED budget
+      and returns the updated `BudgetResponse` (200)
+- [ ] Attempting it on a LOCKED budget is rejected (409, existing locked-budget
+      exception path) with no change
+- [ ] A month/year that collides with another non-deleted budget is rejected
+      with the same duplicate error that `POST /api/budgets` uses (no new error
+      semantics)
+- [ ] Setting month/year to the budget's current values is a no-op success (not
+      treated as a duplicate against itself)
+- [ ] Month is validated 1–12 and year is required, matching `CreateBudgetRequest`
+- [ ] Line items (income/expenses/savings) and totals are untouched by the edit
+- [ ] Frontend: on `/budgets/:id` for an UNLOCKED budget, an "Edit period"
+      action opens a modal (month + year) that saves through a new
+      `useUpdateBudget` mutation and invalidates the budget queries
+- [ ] The edit action is absent on LOCKED budgets
+
+## API changes (if backend)
+
+New endpoint, additive and non-breaking (the deployed frontend never calls it):
+
+```
+PUT /api/budgets/{id}
+Body: UpdateBudgetRequest { Integer month (1–12, required), Integer year (required) }
+200 -> BudgetResponse
+409 -> budget is locked
+409/400 -> duplicate month/year (reuse existing DuplicateBudget* exception)
+404 -> not found
+```
+
+Add `UpdateBudgetRequest` to `BudgetDtos`, a `updateBudget` method through
+`IDomainService`/`DomainService` (business rules: locked check, duplicate check
+that excludes the budget's own id) and `IDataService`/`DataService` (existence
+query that excludes a given id). Reuse the existing duplicate/locked exceptions
+rather than inventing new ones.
+
+## UI notes (if frontend)
+
+- Reuse the modal + React Hook Form + Zod pattern already used by the budget
+  wizard's month step; a simple month dropdown (sv-SE month names) + year input.
+- Add `useUpdateBudget(id)` next to the existing budget hooks; invalidate the
+  budget detail and budget list query keys on success; surface errors via the
+  existing toast pattern.
+- Place the trigger near the existing lock/unlock/delete actions on
+  `BudgetDetailPage`, visible only when `status === "UNLOCKED"`.
+
+## Out of scope
+
+- Editing month/year of LOCKED budgets (must unlock first — keeps the
+  lock invariant intact)
+- Any change to line items, transfers, or the wizard
+- Reordering/“move budget” semantics beyond the uniqueness check
+
+## Notes
+
+- Backend touch points: `BudgetController` (`@PutMapping("/{id}")`),
+  `DomainService` (budget creation duplicate/locked logic to mirror),
+  `DataService` (uniqueness query — add an "exists by month/year excluding id"
+  variant), `BudgetDtos`.
+- The uniqueness rule is "unique month+year among non-deleted budgets"; the
+  self-exclusion is the only subtlety. Cover it with an explicit test.
+- No migration needed — schema is unchanged.

--- a/product/backlog/040-todo-progress-on-budget-cards.md
+++ b/product/backlog/040-todo-progress-on-budget-cards.md
@@ -1,0 +1,83 @@
+# Show todo-list progress on locked budget cards
+
+- **ID:** 040-todo-progress-on-budget-cards
+- **Scope:** full-stack
+- **Size:** S
+
+## Why
+
+During the "execute" phase of the month the couple works through a locked
+budget's todo list (transfers + payments). The `/budgets` grid shows each
+budget's status and totals, but gives no sense of how far along the month's
+tasks are — you must open each budget's todo page to find out. A small "X of Y
+done" on the card turns the budget grid into an at-a-glance monthly progress
+view, reinforcing the routine Balance is built around.
+
+## What
+
+On the `/budgets` grid, each **LOCKED** budget card shows its todo progress
+(completed vs total items), e.g. a compact "5 / 8 done" label and/or a thin
+progress bar. UNLOCKED budgets show nothing new (they have no todo list). The
+backend already computes these counts for the todo page; expose them on the
+budget list response so the grid needs no per-card extra fetch.
+
+## Acceptance criteria
+
+- [ ] `GET /api/budgets` includes, for each LOCKED budget, a todo summary with
+      total and completed counts; UNLOCKED budgets carry null/absent summary
+- [ ] The added field is optional/additive — the currently deployed frontend
+      keeps working unchanged (no field removed or renamed)
+- [ ] No N+1: counts come from an aggregate query (or batch), not one query per
+      budget
+- [ ] Frontend: LOCKED budget cards render "completed / total done" using the
+      new field; the count matches the budget's todo page
+- [ ] A locked budget with 0 completed shows "0 / N"; all-complete shows
+      "N / N" (and visually reads as done)
+- [ ] UNLOCKED cards are visually unchanged
+- [ ] Tests: backend asserts the summary is present for locked and
+      null/absent for unlocked; frontend asserts the label renders from the
+      field and is hidden for unlocked
+
+## API changes (if backend)
+
+Additive field on the existing `BudgetResponse` (used by both `GET /api/budgets`
+and `GET /api/budgets/{id}`):
+
+```
+BudgetResponse {
+  ... existing fields ...,
+  TodoProgress todoProgress   // null for UNLOCKED budgets
+}
+TodoProgress { int totalItems, int completedItems }
+```
+
+Reuse the existing todo counting logic (`TodoSummaryResponse` already exposes
+`totalItems`/`completedItems`). Populate it when mapping budgets in the list
+path; prefer a single grouped count query over per-budget lookups. Adding a
+nullable field to a JSON response is backward compatible for the deployed
+frontend (Jackson ignores unknown/extra fields; the new field is simply unread
+by old clients).
+
+## UI notes (if frontend)
+
+- Reuse the existing budget card component on the `/budgets` grid and the
+  shadcn/ui primitives already in use; a minimal text label is enough, an
+  optional thin progress bar (existing Progress component if present) is a plus.
+- Keep sv-SE conventions; this is counts, not currency.
+- Gate rendering on `status === "LOCKED" && todoProgress != null`.
+
+## Out of scope
+
+- Per-item breakdown on the card (that's the todo page's job)
+- Any change to the todo page itself or to optimistic checkbox behavior
+- Charts/visualizations beyond a simple count/bar (reports are a non-goal)
+
+## Notes
+
+- Backend touch points: `BudgetDtos.BudgetResponse`, `BudgetExtensions`
+  (mapping), `DomainService` budget-list path, a repository count query for
+  todo items grouped by budget. Confirm whether todo items are reachable via an
+  aggregate query to avoid N+1.
+- Frontend touch points: the budgets grid/card component and its types in
+  `src/api`.
+- No migration needed.

--- a/product/backlog/050-lock-transfer-preview.md
+++ b/product/backlog/050-lock-transfer-preview.md
@@ -1,0 +1,83 @@
+# Preview the computed transfers before locking a budget
+
+- **ID:** 050-lock-transfer-preview
+- **Scope:** full-stack
+- **Size:** M
+
+## Why
+
+Locking is the pivotal, semi-committing step: it computes the minimal set of
+inter-account transfers, generates the todo list, and moves real money between
+account balances. Today the couple can't see what transfers the lock will
+produce until after it has already happened (then they'd have to unlock to
+change anything). A read-only preview of the planned transfers before
+confirming builds trust in the greedy algorithm and catches "wait, that's the
+wrong account" mistakes while they're still cheap to fix.
+
+## What
+
+Before locking an UNLOCKED budget, the couple can see the exact transfers the
+lock would create — "move 2 500 kr from Checking to Savings", etc. — computed
+without any side effects, and then confirm or cancel. The preview uses the same
+calculation the lock uses, so what they see is what they get. It changes no
+balances, creates no todo list, and stamps no recurring templates.
+
+## Acceptance criteria
+
+- [ ] A new read-only endpoint returns the planned transfers for an UNLOCKED
+      budget using the same logic as lock (`TransferCalculationUtils`), with
+      **zero** persistence side effects (no balance change, no todo list, no
+      recurring stamps)
+- [ ] Each transfer entry identifies the from-account, to-account, and amount
+- [ ] Calling it on a LOCKED budget returns the already-applied transfers, or a
+      clear 409 — pick one and document it (simplest consistent interpretation)
+- [ ] A budget whose plan needs no transfers returns an empty list (not an error)
+- [ ] Frontend: the lock action first opens a confirmation modal listing the
+      previewed transfers (sv-SE / SEK formatted), with Confirm (proceeds to the
+      existing lock call) and Cancel
+- [ ] If the preview is empty, the modal says so plainly and still allows
+      confirming the lock
+- [ ] Tests: backend asserts the preview matches what lock would do and that no
+      state changed after calling it; frontend asserts the modal lists transfers
+      and that Confirm triggers the lock mutation
+
+## API changes (if backend)
+
+Additive, non-breaking read endpoint:
+
+```
+GET /api/budgets/{id}/transfer-preview
+200 -> { List<TransferPreview> transfers }   TransferPreview { fromAccount{id,name}, toAccount{id,name}, BigDecimal amount }
+404 -> not found
+(409 if LOCKED, if that interpretation is chosen)
+```
+
+Reuse `TransferCalculationUtils.calculateTransfers(...)` exactly as the lock
+path does; the domain method must be a pure read (no `@Transactional` write, no
+saves). Map `TransferPlan` to a response DTO via an extension. Do not refactor
+the lock flow itself beyond extracting the shared calculation call if needed
+(note any such extraction in the PR rather than expanding scope).
+
+## UI notes (if frontend)
+
+- Reuse the existing confirmation-modal pattern and shadcn/ui dialog; this
+  replaces the current immediate lock action with a preview-then-confirm step.
+- Fetch the preview with a React Query query (not a mutation) keyed by budget
+  id; format amounts with the existing sv-SE / SEK helper.
+- On Confirm, call the existing lock mutation; keep its current success/error
+  toasts and navigation to the todo page.
+
+## Out of scope
+
+- Editing/overriding the computed transfers (the algorithm is authoritative)
+- Any change to the lock algorithm or to unlock
+- Showing balance-after-lock projections per account (possible future item)
+
+## Notes
+
+- Backend touch points: `BudgetController` (new `@GetMapping`),
+  `DomainService` (a side-effect-free preview method calling the same util),
+  `TransferCalculationUtils` (unchanged), a `TransferPlan → DTO` extension.
+- Strongest test is a "no state changed" assertion: snapshot balances / todo
+  existence before and after calling the preview and assert equality.
+- No migration needed.


### PR DESCRIPTION
## What

The product backlog was empty after item 010 shipped. Per the routine's
"Empty backlog" path, this PR proposes three grounded, S/M-sized feature specs
for maintainer review. **Nothing is implemented this run** — the maintainer
approves a spec by merging it, and a future run picks it up.

| ID | Title | Scope | Size |
|---|---|---|---|
| 030 | Edit an unlocked budget's month/year after creation | full-stack | M |
| 040 | Show todo-list progress on locked budget cards | full-stack | S |
| 050 | Preview the computed transfers before locking a budget | full-stack | M |

## Why these (grounding)

- **030** closes a gap STATE.md flags explicitly: "There is no
  `PUT /api/budgets/{id}` — month/year is not editable after creation (backlog
  item 030)." Today fixing a mis-picked month means deleting and rebuilding the
  whole draft.
- **040** turns the `/budgets` grid into an at-a-glance monthly progress view
  during the "execute" phase. The counts already exist server-side
  (`TodoSummaryResponse.totalItems/completedItems`); the spec just surfaces them
  on the list response (additive, non-breaking).
- **050** adds a read-only preview before the committing lock step, reusing
  `TransferCalculationUtils` with zero side effects so the couple can sanity-check
  the planned transfers before money moves.

Each spec keeps within the firm non-goals (no auth, integrations, investments,
debt, reports/charts, export, dark mode, i18n) and notes additive/non-breaking
API shapes so the deployed frontend keeps working.

## Verification

Docs-only change (three new files under `product/backlog/`). No code touched,
so no build/test run applies. Specs follow `product/TEMPLATE.md` and were
checked against current DTOs/controllers (`BudgetDtos`, `BudgetController`,
`TodoDtos`, `TransferCalculationUtils`) for accurate API/file pointers.

## Notes for the maintainer

- These are proposals, not commitments — reprioritize/renumber/drop freely
  before merging.
- Priority order as numbered (030 first). 030 is the only one with a subtle
  invariant (month/year self-exclusion on the uniqueness check), called out in
  its spec.

Backlog item: n/a (backlog-grooming run)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MR5kt526DLPUNi4HgPZgWG)_