### PR TITLE
ci: add per-PR Docker preview-image workflow (item 020)

### DIFF
--- a/.github/workflows/docker-pr-preview.yml
+++ b/.github/workflows/docker-pr-preview.yml
@@ -1,0 +1,103 @@
+name: PR Preview Image
+
+# Builds and pushes a per-PR Docker image tagged `pr-<number>` so a candidate
+# build can be deployed to the test environment before it is merged. This never
+# touches the versioned/`latest` tags — those remain release-please's job (see
+# release.yml). See README "Delivery pipeline" for how the tags are used.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    # Docs-only changes don't change the runtime image, so skip them.
+    paths-ignore:
+      - "**.md"
+      - ".claude/**"
+      - "product/**"
+
+# One in-flight run per PR; newer pushes cancel older preview builds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # Self-contained gate: the image is only built if these tests pass. We run the
+  # suite here (rather than reusing test.yml via workflow_run) so the build-push
+  # job can `needs:` it directly and derive the PR number from the
+  # pull_request event — workflow_run runs in the default-branch context, which
+  # makes that awkward. The trade-off is that the suite also runs in test.yml on
+  # the same PR; the duplicate run is acceptable for a clear, atomic gate.
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: maven
+
+      - name: Run tests with Maven
+        run: ./mvnw clean test
+
+  build-push:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Same-repo PRs (the routine's claude/* branches) have access to secrets;
+      # forked PRs do not. Detect their presence and no-op the push steps when
+      # absent so the workflow never fails on a fork.
+      - name: Check Docker credentials
+        id: creds
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          if [ -n "$DOCKER_USERNAME" ] && [ -n "$DOCKER_PASSWORD" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Docker Hub credentials not available (likely a fork) — skipping image push."
+          fi
+
+      - name: Set up QEMU
+        if: steps.creds.outputs.available == 'true'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: steps.creds.outputs.available == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: steps.creds.outputs.available == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract Docker metadata
+        if: steps.creds.outputs.available == 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: axelnyman/balance-backend
+          # `type=ref,event=pr` -> pr-<number> (branch-name agnostic).
+          # `type=sha` adds a short-SHA tag for traceability. No semver/latest.
+          tags: |
+            type=ref,event=pr
+            type=sha
+
+      - name: Build and push Docker image
+        if: steps.creds.outputs.available == 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ Hub (`axelnyman/balance-backend`), and the Raspberry Pi running production
 pulls them. Merging a feature PR alone does not deploy; the release-PR merge
 is the deploy gate.
 
+### PR preview images
+
+Separately, every open pull request (once its tests pass) publishes a
+multi-arch image tagged **`pr-<number>`** (e.g.
+`axelnyman/balance-backend:pr-42`) plus a short commit-SHA tag, via the
+`docker-pr-preview.yml` workflow. These let the maintainer pull and run a
+candidate build in the **test environment** before deciding to merge. They are
+**not for production**: the workflow never pushes the versioned or `latest`
+tags (those stay exclusively release-please's), and the `pr-<number>` tags are
+not cleaned up automatically, so they accumulate on Docker Hub (automating
+cleanup is a possible follow-up). Docs-only PRs (`**.md`, `.claude/**`,
+`product/**`) skip the build.
+
 ## Where to look next
 
 - [`product/`](product/) — the product workflow: `STATE.md` (what the app is

--- a/product/STATE.md
+++ b/product/STATE.md
@@ -60,7 +60,10 @@ in the item 015 review; focused charts that aid the monthly routine are welcome.
   per repo → the maintainer merges it → GitHub Actions builds multi-arch
   (amd64 + arm64) images → Docker Hub → the Raspberry Pi runs them. Merging a
   feature PR alone does **not** deploy; the release-PR merge is the deploy
-  gate.
+  gate. Separately, each open PR (when its tests pass) publishes a
+  non-production **`pr-<number>`** preview image via `docker-pr-preview.yml` —
+  for trying a candidate build in a test environment before merge; it never
+  pushes `latest`/semver (item 020).
 
 ## Domain model (backend)
 
@@ -153,10 +156,6 @@ Specs live directly in `product/` (filename `NNN-slug.md`, lowest number =
 highest priority). Item 015 scoped six raw feature ideas into these; priority
 order reflects the maintainer's item 015 review (PR preview image first):
 
-- `020` build/push a **per-PR** Docker image (`pr-<number>` tag) for a test
-  deployment (CI, both repos, M) — prioritised first so later features can be
-  test-deployed before merge. (The earlier `unstable`-on-merge image was dropped
-  per the item 015 review; only the per-PR image is wanted.)
 - `030` wizard modal buttons clipped on iPhone (frontend, S)
 - `040` collapse not-due recurring expenses in the wizard (frontend, S)
 - `050` tighter wizard density / smaller desktop quick-add cards (frontend, M)
@@ -175,6 +174,7 @@ order reflects the maintainer's item 015 review (PR preview image first):
 
 | Date | Item | Repos |
 |---|---|---|
+| 2026-06-17 | Per-PR `pr-<number>` Docker preview-image workflows (item 020) | backend (CI+docs), frontend (CI+docs) |
 | 2026-06-17 | Scope six new-feature ideas into specs (item 015) | backend (docs) |
 | 2026-06-15 | Due-recurring hint on budget detail page (item 010) | frontend, backend (bookkeeping) |
 | 2026-06-14 | Rewrite backend README to describe Balance (item 005) | backend |

--- a/product/done/020-pr-preview-images.md
+++ b/product/done/020-pr-preview-images.md
@@ -114,3 +114,55 @@ It must:
 - CI changes can't be fully verified locally; rely on the workflow running on
   the PR itself, and say so in the PR. Use `act` or a syntax check if available,
   but don't claim a green run that didn't happen.
+
+## Completion notes
+
+- **Completed:** 2026-06-17
+- **PRs:**
+  - balance-backend: `claude/youthful-hamilton-rwyeh3` — adds
+    `.github/workflows/docker-pr-preview.yml` + README "PR preview images" note
+    + this bookkeeping.
+  - balance-frontend: `claude/peaceful-hamilton-rwyeh3` — adds
+    `.github/workflows/docker-pr-preview.yml` + README "Docker preview images"
+    note.
+  - No merge ordering between the two (each repo owns its own workflow); cross-
+    linked in the PR bodies.
+
+### Interpretation decisions
+- **Trigger shape:** chose the spec's recommended *self-contained* shape — a
+  `test` job plus a `build-push` job that `needs:` it — over the `workflow_run`
+  alternative. Reason: `workflow_run` executes in the default-branch context,
+  which makes deriving the PR number (and thus the `pr-<number>` tag) awkward;
+  the self-contained gate is atomic and reads top-to-bottom. Trade-off: the
+  test suite also runs in the existing `test.yml`/`ci.yml` on the same PR, i.e.
+  it runs twice. Accepted for a clear, self-gating image build.
+- **Tags:** `docker/metadata-action` with `type=ref,event=pr` (→ `pr-<number>`,
+  branch-name agnostic) plus `type=sha` (short commit SHA, for traceability).
+  No semver/`latest` tags are ever pushed here.
+- **Tag rule precision:** by default `docker/metadata-action`'s `type=ref`
+  events apply to `flavor.latest=auto` only for the default branch, and we set
+  no `latest` flavor, so `latest` cannot be produced — `release.yml` remains the
+  sole source of `latest`/semver.
+- **Secret guarding:** detect Docker Hub credentials in a `creds` step (reading
+  them via `env:` to avoid script injection) and gate the QEMU/Buildx/login/
+  metadata/build steps on their presence, so a fork PR (no secrets) no-ops the
+  push instead of failing. This repo's PRs come from same-repo `claude/*`
+  branches, so credentials are normally present.
+- **Per-repo secret names preserved:** backend uses `DOCKER_USERNAME` /
+  `DOCKER_PASSWORD`; frontend uses `DOCKER_USERNAME` / `DOCKER_TOKEN`. Not
+  renamed.
+- **paths-ignore:** `**.md`, `.claude/**`, `product/**` on both workflows so
+  docs-only PRs don't build an image (backend had no `paths-ignore` before).
+- **Concurrency:** one in-flight preview build per PR
+  (`cancel-in-progress: true`, keyed on the PR number) so rapid pushes don't
+  pile up multi-arch builds.
+
+### Deviations / not done
+- `release.yml`, `release-please` config, manifests, and the Dockerfiles are
+  unchanged, per spec.
+- **Verification:** GitHub Actions workflows can't be executed locally in this
+  environment. Validated both files parse as YAML (`yaml.safe_load`). The real
+  green run only happens when these PRs trigger the workflow on GitHub — called
+  out in both PR bodies. No green CI run is claimed here.
+- **Follow-up (out of scope, noted in spec):** automatic cleanup of accumulated
+  `pr-<number>` tags on Docker Hub (e.g. a `pull_request: closed` job).


### PR DESCRIPTION
## What

Adds `.github/workflows/docker-pr-preview.yml` so every open pull request publishes a **non-production** preview image to `axelnyman/balance-backend`, letting the maintainer pull and run a candidate build in a test environment **before** deciding to merge.

On `pull_request` (`opened` / `synchronize` / `reopened`, non-docs changes):
1. **`test`** job runs the suite (`./mvnw clean test`).
2. **`build-push`** job `needs:` it and — only if green — builds a multi-arch (`linux/amd64,linux/arm64`) image tagged **`pr-<number>`** (from `type=ref,event=pr`, branch-name agnostic) plus a short commit-SHA tag (`type=sha`).

Also: README "PR preview images" note, and the product bookkeeping for this item (spec moved to `product/done/` with completion notes; `STATE.md` updated).

## Why

Today images are only built when release-please's release PR is merged (the deliberate deploy gate), so there's no way to try a candidate build while it's under review. A `pr-<number>` image fixes exactly that without touching the versioned/`latest` line production pulls.

## Acceptance criteria

- [x] On `pull_request` with non-docs changes, runs tests and — only if they pass — builds & pushes a multi-arch image tagged `pr-<number>`
- [x] Docs-only changes (`**.md`, `.claude/**`, `product/**`) skip the build (`paths-ignore`)
- [x] Failing tests block the push (`build-push` `needs: test`)
- [x] Never pushes `latest` or semver — `release.yml` unchanged
- [x] Reuses existing `DOCKER_USERNAME` / `DOCKER_PASSWORD` secrets and the existing Dockerfile (unchanged)
- [x] Image name matches production (`axelnyman/balance-backend`) with the `pr-<number>` tag
- [x] README note explains the tags and that they're not for production

## Design decisions

- **Self-contained gate** (test job + `build-push` `needs:` it) chosen over `workflow_run` — `workflow_run` runs in the default-branch context, which makes deriving the PR number awkward. Trade-off: the suite also runs in the existing `test.yml` on the same PR (runs twice); accepted for an atomic, readable gate.
- **Secret guard:** a `creds` step (reads secrets via `env:` to avoid script injection) detects whether Docker Hub credentials are present and no-ops the push steps when absent, so fork PRs don't fail. This repo's PRs come from same-repo `claude/*` branches, so credentials are normally present.
- **Concurrency:** one in-flight preview build per PR (`cancel-in-progress`).
- Backend had no `paths-ignore` before; this workflow adds one.

## Verification

GitHub Actions workflows can't be executed locally here. I validated that both repos' workflow files parse as YAML (`yaml.safe_load` → OK). **No green Actions run is claimed** — the real run happens when this PR triggers the workflow on GitHub; please confirm the `pr-<number>` image appears once CI runs.

## Limitations / follow-up

- `pr-<number>` tags accumulate on Docker Hub; automatic cleanup (e.g. a `pull_request: closed` job) is noted as out-of-scope follow-up.

## Related

Sibling frontend PR (no merge ordering between them): https://github.com/axel-nyman/balance-frontend/pull/16

Backlog item: 020-pr-preview-images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhXqGzCqQ272usdrA6843V)_