### PR TITLE
docs: mark item 030 (wizard modal safe-area) done and update STATE

### DIFF
--- a/product/STATE.md
+++ b/product/STATE.md
@@ -6,8 +6,7 @@
 > `CHANGELOG.md` (generated — never hand-edit), and `.claude/thoughts/` in
 > both repos for engineering research and plans.
 
-**Last updated:** 2026-06-17 (scoped new-feature backlog from item 015; revised
-per maintainer review — see Open backlog)
+**Last updated:** 2026-06-17 (item 030 done — wizard modal safe-area fix)
 
 ## What Balance is
 
@@ -156,7 +155,6 @@ Specs live directly in `product/` (filename `NNN-slug.md`, lowest number =
 highest priority). Item 015 scoped six raw feature ideas into these; priority
 order reflects the maintainer's item 015 review (PR preview image first):
 
-- `030` wizard modal buttons clipped on iPhone (frontend, S)
 - `040` collapse not-due recurring expenses in the wizard (frontend, S)
 - `050` tighter wizard density / smaller desktop quick-add cards (frontend, M)
 - `060` near-real-time refresh to sync two open sessions (frontend, S)
@@ -174,6 +172,7 @@ order reflects the maintainer's item 015 review (PR preview image first):
 
 | Date | Item | Repos |
 |---|---|---|
+| 2026-06-17 | Wizard item modal buttons clear the iPhone home indicator (item 030) | frontend, backend (bookkeeping) |
 | 2026-06-17 | Per-PR `pr-<number>` Docker preview-image workflows (item 020) | backend (CI+docs), frontend (CI+docs) |
 | 2026-06-17 | Scope six new-feature ideas into specs (item 015) | backend (docs) |
 | 2026-06-15 | Due-recurring hint on budget detail page (item 010) | frontend, backend (bookkeeping) |

--- a/product/done/030-wizard-modal-button-safe-area.md
+++ b/product/done/030-wizard-modal-button-safe-area.md
@@ -91,3 +91,31 @@ than inventing a new one).
 - **Not verified:** On-device pixel confirmation on a physical iPhone is the
   maintainer's to do (per the spec's note); the change is reasoned from the CSS.
 - **Deviations / cut:** None.
+
+### Follow-up after maintainer review (2026-06-19)
+
+On-device review of the frontend PR found the original `env()`-based change had
+**no effect** in the installed PWA, and clarified the real symptom: the
+bottom-most **Delete** button's *left/right* edges are clipped by the phone's
+rounded corners (the bottom edge is fine).
+
+- **Root cause:** the app's viewport meta is `width=device-width,
+  initial-scale=1.0` with **no `viewport-fit=cover`**. Without it, iOS keeps the
+  web view inside the safe area and every `env(safe-area-inset-*)` resolves to
+  `0` — so `pb-[max(0.5rem,env(safe-area-inset-bottom))]` collapsed to plain
+  `0.5rem` (unchanged). The existing `index.css` `.mobile-content` /
+  `.mobile-sidebar` safe-area blocks are inert for the same reason. In portrait
+  the browser reserves the home-indicator area (bottom fine) but
+  `safe-area-inset-left/right` are `0`, so full-width buttons reach the physical
+  edges where the corner radius clips them.
+- **Corrected fix:** dropped `env()` (it's `0` here) for literal, mobile-gated
+  footer padding — `flex-col gap-2 px-4 pb-4 sm:px-0 sm:pb-2`. `px-4 pb-4` insets
+  the buttons clear of the rounded corners on phones; `sm:px-0 sm:pb-2` restores
+  the exact edge-to-edge desktop spacing (desktop unchanged). Test updated to
+  assert the responsive padding utilities. Suite green: lint (0 errors),
+  `tsc --noEmit` clean, 499 tests pass, build succeeds; frontend PR CI green.
+- **Noted for the maintainer (not done here):** real app-wide safe-area handling
+  (which would also activate the dormant `index.css` blocks) needs
+  `viewport-fit=cover` on the viewport meta — a broader change requiring
+  on-device checks across every screen; left out of this narrow fix and offered
+  as a possible separate backlog item.

--- a/product/done/030-wizard-modal-button-safe-area.md
+++ b/product/done/030-wizard-modal-button-safe-area.md
@@ -68,3 +68,26 @@ than inventing a new one).
 - Hard to verify pixel-perfectly without the physical device; the implementer
   should reason from the CSS and note in the PR that on-device confirmation is
   the maintainer's to do.
+
+## Completion notes
+
+- **Date:** 2026-06-17
+- **PRs:** balance-frontend (this item's implementation) + balance-backend (this
+  bookkeeping). Cross-linked; no merge-order dependency (frontend-only change).
+- **Interpretation:** Replaced the wizard item modal footer's fixed `pb-2` with
+  `pb-[max(0.5rem,env(safe-area-inset-bottom))]`. The `max()` keeps the existing
+  0.5rem floor on devices that report no safe-area inset (desktop, unchanged),
+  and grows the bottom padding to the inset on notched/rounded phones so the
+  "Done"/"Delete" buttons clear the home indicator.
+- **Scope decision:** Made the change on `WizardItemEditModal`'s footer only, not
+  the shared `SheetContent` primitive. `side="bottom"` is used in exactly one
+  place in the codebase (the wizard item modal), so the narrowest fix fully
+  covers the reported bug; no other bottom sheet shares it. All three uses
+  (income/expenses/savings) share this component, so all are covered.
+- **Tests:** Added `WizardItemEditModal.test.tsx` — asserts the action buttons
+  render and that the footer carries the safe-area padding utility. Full
+  frontend suite green: lint (0 errors), `tsc --noEmit` clean, 499 tests across
+  55 files pass, `npm run build` succeeds.
+- **Not verified:** On-device pixel confirmation on a physical iPhone is the
+  maintainer's to do (per the spec's note); the change is reasoned from the CSS.
+- **Deviations / cut:** None.

--- a/src/main/java/org/example/axelnyman/main/MainApplication.java
+++ b/src/main/java/org/example/axelnyman/main/MainApplication.java
@@ -4,6 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+/**
+ * Application entry point for the Balance backend REST API.
+ */
 @SpringBootApplication
 @EnableJpaAuditing
 public class MainApplication {


### PR DESCRIPTION
## What & why

Product bookkeeping for backlog item **030** (wizard item modal buttons clipped by the iPhone home indicator). The feature itself is frontend-only; this PR carries the required backend-side bookkeeping.

- Moves `product/030-wizard-modal-button-safe-area.md` → `product/done/` with a **Completion notes** section (date, PR links, interpretation, scope decision, test evidence).
- Updates `product/STATE.md`: removes 030 from the open backlog and adds it to the "Recently completed" table; refreshes the "Last updated" line.

No code or schema changes.

Backlog item: 030-wizard-modal-button-safe-area

Implementation PR (frontend): axel-nyman/balance-frontend #17. No merge-order dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPTbfXp6BoFBcW1cd3KVi7

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPTbfXp6BoFBcW1cd3KVi7)_