### PR TITLE
docs: mark item 040 (collapse non-due recurring in wizard) done and update STATE

### DIFF
--- a/product/STATE.md
+++ b/product/STATE.md
@@ -6,8 +6,8 @@
 > `CHANGELOG.md` (generated — never hand-edit), and `.claude/thoughts/` in
 > both repos for engineering research and plans.
 
-**Last updated:** 2026-06-17 (scoped new-feature backlog from item 015; revised
-per maintainer review — see Open backlog)
+**Last updated:** 2026-06-18 (item 040 — collapse non-due recurring expenses in
+the budget wizard)
 
 ## What Balance is
 
@@ -108,7 +108,9 @@ Money is `BigDecimal` / `NUMERIC(19,2)` everywhere. Flyway migrations V1–V4
 - `/budgets` — budget card grid (status + totals); "new budget" leads to the
   wizard (one unlocked budget at a time — enforced in UI and backend).
 - `/budgets/new` — 5-step wizard; copy-from-last-budget; due templates grouped
-  with "add all due"; create requires balance = 0.
+  with "add all due"; non-due recurring templates are tucked behind a
+  "Show other recurring expenses (N)" collapsible on the expenses step
+  (item 040); create requires balance = 0.
 - `/budgets/:id` — income/expenses/savings sections with add/edit/delete
   modals (UNLOCKED only); summary with balance bar; lock/unlock/delete
   actions; link to the todo page when locked. On UNLOCKED budgets a
@@ -157,7 +159,6 @@ highest priority). Item 015 scoped six raw feature ideas into these; priority
 order reflects the maintainer's item 015 review (PR preview image first):
 
 - `030` wizard modal buttons clipped on iPhone (frontend, S)
-- `040` collapse not-due recurring expenses in the wizard (frontend, S)
 - `050` tighter wizard density / smaller desktop quick-add cards (frontend, M)
 - `060` near-real-time refresh to sync two open sessions (frontend, S)
 - `070a–070e` **savings goals** (split: backend foundation → goals pages →
@@ -174,6 +175,7 @@ order reflects the maintainer's item 015 review (PR preview image first):
 
 | Date | Item | Repos |
 |---|---|---|
+| 2026-06-18 | Collapse non-due recurring expenses in the budget wizard (item 040) | frontend, backend (bookkeeping) |
 | 2026-06-17 | Per-PR `pr-<number>` Docker preview-image workflows (item 020) | backend (CI+docs), frontend (CI+docs) |
 | 2026-06-17 | Scope six new-feature ideas into specs (item 015) | backend (docs) |
 | 2026-06-15 | Due-recurring hint on budget detail page (item 010) | frontend, backend (bookkeeping) |

--- a/product/done/040-wizard-hide-non-due-recurring.md
+++ b/product/done/040-wizard-hide-non-due-recurring.md
@@ -58,3 +58,39 @@ toggle are visible. Expanding shows the same quick-add cards that exist today.
 ## Notes
 
 - Pairs naturally with item 050 (wizard density) but is independently shippable.
+
+## Completion notes
+
+- **Date:** 2026-06-18
+- **PRs:** frontend axel-nyman/balance-frontend (branch
+  `claude/peaceful-hamilton-tx79tf`); backend bookkeeping (this branch
+  `claude/youthful-hamilton-tx79tf`). Frontend-only feature — no merge-order
+  dependency.
+- **Implementation:** In `StepExpenses.tsx` the non-due ("Other recurring")
+  group is now wrapped in the existing shadcn `Collapsible`, collapsed by
+  default. The trigger is a ghost button reading
+  `Show other recurring expenses (N)` when collapsed (N = number of hidden
+  non-due templates) and `Hide other recurring expenses` when expanded, with the
+  same chevron-rotate affordance used by the review step. The "Due this month"
+  group is unchanged (expanded, "Add All"). Expanding renders the exact same
+  `WizardItemCard variant="quick-add"` cards wrapped in `CollapseWrapper`, so add
+  behaviour, copy animations, and "added" feedback are preserved.
+- **Interpretation decisions:**
+  - Chose the inline `Collapsible` (the spec's preferred option) over a modal.
+  - The toggle replaces the former static `Other recurring` /
+    `Quick add from recurring` heading; when there are no due templates the
+    toggle is the only recurring control and the step still reads sensibly (AC).
+  - Collapsed by default in all cases, including the no-due-templates case (the
+    spec does not ask for auto-expand there).
+  - Radix `CollapsibleContent` unmounts when closed, so non-due cards occupy no
+    vertical space until expanded (satisfies the "do not occupy vertical space"
+    AC) and are absent from the DOM/tests until the toggle is opened.
+- **Tests:** Updated the existing
+  `shows quick-add section when recurring expenses exist` test (non-due item is
+  now behind the toggle) and added a `non-due recurring collapse` describe block
+  covering due-only, non-due-only, both, and neither, plus expand/collapse and
+  adding from the expanded list. Full frontend suite green: `npm run lint`
+  (0 errors, 7 pre-existing warnings), `npx tsc --noEmit` clean,
+  `npm test -- --run` 503 passed (54 files), `npm run build` succeeds.
+- **Deviations / cut:** none. No backend change (template data already comes
+  from `GET /api/recurring-expenses`).


### PR DESCRIPTION
## What & why

Product bookkeeping for backlog item **040** (tuck "not due this month"
recurring expenses behind a collapsible toggle in the budget wizard's expenses
step). The feature itself is frontend-only; this PR carries the required
backend-side bookkeeping.

- Moves `product/040-wizard-hide-non-due-recurring.md` → `product/done/` with a
  **Completion notes** section (date, PR links, interpretation decisions, test
  evidence).
- Updates `product/STATE.md`: refreshes the wizard page description, removes 040
  from the open backlog, adds it to the "Recently completed" table, and updates
  the "Last updated" line.

No code or schema changes.

Backlog item: 040-wizard-hide-non-due-recurring

Implementation PR (frontend): axel-nyman/balance-frontend #18. Frontend-only —
no merge-order dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DcC5TkT3mGhm6aUL7eHfTy

---
_Generated by [Claude Code](https://claude.ai/code/session_01DcC5TkT3mGhm6aUL7eHfTy)_