### PR TITLE
ci: enforce Conventional Commit PR titles and align release config

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,21 @@
+name: PR Title Lint
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    steps:
+      # PRs are squash-merged with the PR title as the commit subject, and
+      # release-please parses those commits to drive versions and the changelog.
+      # Enforce that every PR title is a valid Conventional Commit so the
+      # squashed commit on main is always parseable.
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/product/ROUTINE_PROMPT.md
+++ b/product/ROUTINE_PROMPT.md
@@ -122,8 +122,10 @@ not run and why in the PR body. Never imply verification that didn't happen.
 
 ### 8. Deliver
 - Push your branch(es) and open **one PR per touched repo**.
-- PR title in Conventional Commit style (squash-merge turns it into the
-  release-driving commit). PR body: what + why, `Backlog item: <id>`, test
+- PR title in Conventional Commit style — a `PR Title Lint` check enforces it
+  and squash-merge turns it into the release-driving commit on `main`, so a
+  non-conventional title fails CI and blocks the merge. PR body: what + why,
+  `Backlog item: <id>`, test
   evidence (commands and results), assumptions/limitations, screenshots for UI
   changes when possible. For full-stack items, cross-link the sibling PR and
   state the merge order (backend first).

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,16 @@
   "release-type": "maven",
   "packages": {
     ".": {
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "refactor", "section": "Code Refactoring" },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true }
+      ]
     }
   }
 }


### PR DESCRIPTION
## What

1. **`.github/workflows/pr-title-lint.yml`** (`amannn/action-semantic-pull-request`) — fails any PR whose title isn't a valid Conventional Commit.
2. **`release-please-config.json`** — adds `changelog-sections` mirroring the frontend, so `docs:` / `chore:` / `test:` commits are hidden from the changelog (feat/fix/perf/refactor stay visible).
3. **`product/ROUTINE_PROMPT.md`** — notes that PR titles are now CI-enforced by the `PR Title Lint` check (the agent already wrote conventional titles; this records the enforcement).

## Why

PRs currently land on `main` as `Merge pull request #N …` merge commits. release-please reads the buried conventional commits, but the strategy is fragile — the pending release PR (#41) contains a **duplicate** "rewrite backend README" entry caused by merge-commit attribution, and the changelog is a wall of `docs:` bookkeeping noise.

Squash-merging makes each PR exactly one conventional commit on `main`; the title lint guarantees it's parseable; and the changelog-sections config drops the doc/chore noise.

## ⚠️ Required repo setting (this PR is only half the fix)

In **Settings → General → Pull Requests**:

- Enable **Squash merging**, set **Default commit message → "Pull request title"**
- **Uncheck "Allow merge commits"** so squash is the only path

## Effect on releases

Once this lands on `main`, release-please regenerates PR #41 without the doc-noise/duplicate. Heads-up: the backend has historically cut patch releases on `docs:`-only batches; watch the first post-merge release PR, and if you'd prefer docs-only batches not to cut a backend release at all (no pointless Docker rebuild), say so and I'll wire that up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FcEBPtRqpeaFPjMgtYZcLH

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcEBPtRqpeaFPjMgtYZcLH)_