### PR TITLE
docs: mark item 050 (wizard quick-add density) done and update STATE

### DIFF
--- a/product/STATE.md
+++ b/product/STATE.md
@@ -6,8 +6,8 @@
 > `CHANGELOG.md` (generated — never hand-edit), and `.claude/thoughts/` in
 > both repos for engineering research and plans.
 
-**Last updated:** 2026-06-18 (item 040 — collapse non-due recurring expenses in
-the budget wizard)
+**Last updated:** 2026-06-23 (item 050 — tighten budget wizard quick-add card
+density)
 
 ## What Balance is
 
@@ -110,7 +110,10 @@ Money is `BigDecimal` / `NUMERIC(19,2)` everywhere. Flyway migrations V1–V4
 - `/budgets/new` — 5-step wizard; copy-from-last-budget; due templates grouped
   with "add all due"; non-due recurring templates are tucked behind a
   "Show other recurring expenses (N)" collapsible on the expenses step
-  (item 040); create requires balance = 0.
+  (item 040); create requires balance = 0. Recurring quick-add cards are a
+  single compact row (name + amount + add) with the bank account deferred until
+  the item is added — set from the template default and editable afterwards —
+  and tighter padding at `md+` so more fit on desktop (item 050).
 - `/budgets/:id` — income/expenses/savings sections with add/edit/delete
   modals (UNLOCKED only); summary with balance bar; lock/unlock/delete
   actions; link to the todo page when locked. On UNLOCKED budgets a
@@ -152,13 +155,12 @@ Money is `BigDecimal` / `NUMERIC(19,2)` everywhere. Flyway migrations V1–V4
   only `done/` is a real subdir. Treat "the backlog" as the `NNN-*.md` files in
   `product/` until the docs are reconciled.
 
-## Open backlog (as of 2026-06-18)
+## Open backlog (as of 2026-06-23)
 
 Specs live directly in `product/` (filename `NNN-slug.md`, lowest number =
 highest priority). Item 015 scoped six raw feature ideas into these; priority
 order reflects the maintainer's item 015 review (PR preview image first):
 
-- `050` tighter wizard density / smaller desktop quick-add cards (frontend, M)
 - `060` near-real-time refresh to sync two open sessions (frontend, S)
 - `070a–070e` **savings goals** (split: backend foundation → goals pages →
   budget linking on lock → manual-balance reallocation → progress/predictions).
@@ -174,6 +176,7 @@ order reflects the maintainer's item 015 review (PR preview image first):
 
 | Date | Item | Repos |
 |---|---|---|
+| 2026-06-23 | Tighten budget wizard quick-add card density (item 050) | frontend, backend (bookkeeping) |
 | 2026-06-18 | Collapse non-due recurring expenses in the budget wizard (item 040) | frontend, backend (bookkeeping) |
 | 2026-06-17 | Wizard item modal buttons clear the iPhone home indicator (item 030) | frontend, backend (bookkeeping) |
 | 2026-06-17 | Per-PR `pr-<number>` Docker preview-image workflows (item 020) | backend (CI+docs), frontend (CI+docs) |

--- a/product/done/050-wizard-density.md
+++ b/product/done/050-wizard-density.md
@@ -69,3 +69,47 @@ quick-add cards:
 - Could be split into 050a (defer detail) and 050b (desktop downsize) if it
   runs long; they share the same files so a single PR is preferred.
 - Coordinate with item 040 if both are in flight (same file).
+
+## Completion notes
+
+- **Date:** 2026-06-23
+- **PRs:** balance-frontend (feat) + balance-backend (docs, this bookkeeping).
+- **Scope delivered:** frontend-only, both density improvements in one change to
+  `src/components/wizard/WizardItemCard.tsx` (quick-add variant) — reused by both
+  the due and non-due lists so item 040's collapse still composes cleanly.
+
+### Interpretation decisions
+- **Defer detail (AC1):** hid the bank account entirely on the quick-add card
+  and collapsed the card from two rows to a single row (name on the left,
+  amount + add control on the right). Kept the amount visible — the spec allows
+  hiding it optionally, but the cost of an expense aids the "do I want this this
+  month?" decision, so only the account (the truly secondary detail) is
+  deferred. The account is still applied from the template default on add
+  (`handleAddRecurring` unchanged) and stays editable in the item modal / the
+  desktop expense row's `AccountSelect`.
+- **Desktop downsize (AC3):** the single-row layout plus tighter padding at
+  `md+` (`p-4 md:px-3 md:py-2`) makes the cards visibly more compact on desktop
+  while mobile keeps `p-4` and the `h-8 w-8` add tap target.
+- **Layout choice:** kept the vertical stack rather than introducing a
+  `md:grid-cols-2` grid. A grid was considered (the spec lists it as a
+  possibility) but deferred: the per-card collapse and the "Add All" cascade
+  animations are height-based and tuned for a single column; a 2-col grid would
+  leave transient row-height gaps mid-collapse. The single-row + padding change
+  already delivers a clear desktop density win without risking the animations.
+
+### Deviations / cut
+- No multi-column grid (see above) — noted as a possible future polish.
+- No separate card "expanded state" for showing the deferred account; the modal
+  and the expense row already expose/let you edit the account, so a third
+  surface was unnecessary.
+
+### Test evidence (balance-frontend)
+- New `src/components/wizard/WizardItemCard.test.tsx` (4 tests): quick-add shows
+  name/amount/add control but not the account; `onQuickAdd` fires; md+ padding
+  overrides present while mobile `p-4` and the `h-8 w-8` tap target are kept.
+- Updated `StepExpenses.test.tsx`: the former "shows bank account name on
+  quick-add card" test now asserts the account is deferred (name + amount shown,
+  account hidden until add). The existing pre-fill test still verifies the added
+  expense row gets the template's default account.
+- `npm run lint` (0 errors, pre-existing warnings only), `npx tsc --noEmit`
+  clean, `npm test -- --run` → 56 files / 509 tests passing, `npm run build` ok.


### PR DESCRIPTION
Product bookkeeping for backlog item **050-wizard-density** (a frontend-only change). No code changes here.

## What

- Moves `product/050-wizard-density.md` → `product/done/` with a `## Completion notes` section (date, PR links, interpretation decisions, deviations, test evidence).
- Updates `product/STATE.md`: the `/budgets/new` wizard description, the open-backlog list (removes 050), and the "Recently completed" table.

## Sibling PR

Frontend implementation: axel-nyman/balance-frontend#20 (the `feat:` change). **Merge order:** the frontend change is independently mergeable; merge this docs PR alongside it.

Backlog item: 050-wizard-density

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwM5cRRnrMvKGweaPrsw5R)_