### PR TITLE
docs: mark item 060 (near-real-time refresh) done and update STATE

### DIFF
--- a/product/STATE.md
+++ b/product/STATE.md
@@ -6,7 +6,7 @@
 > `CHANGELOG.md` (generated — never hand-edit), and `.claude/thoughts/` in
 > both repos for engineering research and plans.
 
-**Last updated:** 2026-06-23 (item 055 — clean up CI and agentic workflows)
+**Last updated:** 2026-06-23 (item 060 — near-real-time cross-device refresh)
 
 ## What Balance is
 
@@ -130,6 +130,10 @@ Money is `BigDecimal` / `NUMERIC(19,2)` everywhere. Flyway migrations V1–V4
   commit) — release-please derives versions from them.
 - Modal-based editing only; explicit save everywhere except todo checkboxes
   (optimistic updates). Apple-inspired clean, light, mobile-first UI.
+- The user-visible read queries (budget list/detail, accounts, recurring
+  expenses, todo list) background-poll every 30s (`POLL_INTERVAL` in
+  `src/lib/query-config.ts`) so two open sessions stay in near-real-time sync;
+  polling pauses when the tab is hidden (item 060). Reads only — no push/SSE.
 - Soft deletes everywhere; migrations are additive/backward compatible; never
   edit an applied migration; never hand-edit `CHANGELOG.md`.
 - Engineering conventions live in each repo's `CLAUDE.md` (3-layer
@@ -161,7 +165,6 @@ Specs live directly in `product/` (filename `NNN-slug.md`, lowest number =
 highest priority). Item 015 scoped six raw feature ideas into these; priority
 order reflects the maintainer's item 015 review (PR preview image first):
 
-- `060` near-real-time refresh to sync two open sessions (frontend, S)
 - `070a–070e` **savings goals** (split: backend foundation → goals pages →
   budget linking on lock → manual-balance reallocation → progress/predictions).
   Sizeable new domain — `070a` is the gate. `070a` now includes an append-only
@@ -176,6 +179,7 @@ order reflects the maintainer's item 015 review (PR preview image first):
 
 | Date | Item | Repos |
 |---|---|---|
+| 2026-06-23 | Near-real-time cross-device refresh via React Query polling (item 060) | frontend, backend (bookkeeping) |
 | 2026-06-23 | Clean up CI/preview workflows + tighten agent prompts (item 055) | backend (CI+docs), frontend (CI) |
 | 2026-06-23 | Tighten budget wizard quick-add card density (item 050) | frontend, backend (bookkeeping) |
 | 2026-06-18 | Collapse non-due recurring expenses in the budget wizard (item 040) | frontend, backend (bookkeeping) |

--- a/product/done/060-near-realtime-refresh.md
+++ b/product/done/060-near-realtime-refresh.md
@@ -76,3 +76,51 @@ None. Reads use existing endpoints.
   seconds, not seconds) and visibility-gated so two idle tabs don't hammer the
   API.
 - Data-safe by construction: this item only adds background GETs.
+
+## Completion notes
+
+- **Completed:** 2026-06-23
+- **PRs:** balance-frontend `feat: poll user-visible queries for near-real-time
+  cross-device sync` (branch `claude/peaceful-hamilton-dmkqk9`); balance-backend
+  this `docs:` bookkeeping PR (branch `claude/youthful-hamilton-dmkqk9`).
+- **Scope:** frontend-only feature + backend bookkeeping. No backend code or API
+  changes — reads use existing endpoints.
+
+### Interpretation decisions
+
+- **Per-query `refetchInterval`, not a global default.** Added
+  `refetchInterval: POLL_INTERVAL` to exactly the user-visible read queries —
+  `useBudgets` (list), `useBudget` (detail), `useAccounts`,
+  `useRecurringExpenses`, and `useTodoList` — rather than setting a global on the
+  QueryClient. This keeps non-data / one-off queries (e.g. the balance-history
+  infinite query behind the drawer) unpolled, matching the spec's preference.
+- **Interval = 30s**, defined once as `POLL_INTERVAL` in
+  `src/lib/query-config.ts`. Generous tens-of-seconds value per the Raspberry Pi
+  cost note; two idle tabs poll five endpoints every 30s at most.
+- **Tab-hidden pausing** relies on React Query's default
+  `refetchIntervalInBackground: false` — polling stops when the document is
+  hidden and resumes on visibility. Not set explicitly (it is the default);
+  noted here so the behavior is intentional, not accidental.
+- **Optimistic todo updates untouched.** The existing `onMutate`/`onError`/
+  `onSettled` optimistic flow in `useUpdateTodoItem` is unchanged; `onMutate`
+  still cancels in-flight queries, so a background poll cannot clobber an
+  in-flight toggle. Existing optimistic tests still pass.
+
+### Tests
+
+- New `src/hooks/polling.test.tsx` asserts the budgets-list, budget-detail,
+  accounts, and recurring-expenses queries each carry `refetchInterval ===
+  POLL_INTERVAL`.
+- Extended `src/hooks/use-todo.test.tsx` with the same assertion for the todo
+  query, alongside the pre-existing optimistic-update tests.
+- Full suite: `npm run lint` (warnings only, pre-existing), `npx tsc --noEmit`,
+  `npm test -- --run` (514 passing), and `npm run build` all green. Note: the
+  default parallel `vitest` run intermittently emits teardown "window is not
+  defined" errors from an unrelated wizard animation timer
+  (`useCopyAnimation`); this flake predates this change (the base branch fails
+  the same way) and does not reproduce under
+  `vitest run --no-file-parallelism`, which is fully green.
+
+### Deviations / cut
+
+- None. True push (SSE/WebSocket) remains out of scope as specified.


### PR DESCRIPTION
## What

Product bookkeeping for backlog item **060 — near-real-time cross-device refresh** (a frontend-only feature). Docs-only; no backend code.

- Move `product/060-near-realtime-refresh.md` → `product/done/`, appending `## Completion notes` (interpretation decisions, test evidence, deviations).
- Update `product/STATE.md`: add a conventions bullet describing the 30s background polling, remove 060 from the open backlog, and add it to the Recently completed table.

## Why

The routine requires the backend `product/` system to be updated in the same change as the feature, even for frontend-only items.

`Backlog item: 060-near-realtime-refresh`

## Sibling PR / merge order

The feature itself ships in **axel-nyman/balance-frontend** PR #22 (`feat: poll user-visible queries for near-real-time cross-device sync`). Order doesn't matter — that PR is frontend-only and this is docs-only, fully independent.

## Test evidence

Docs-only — no code changes, nothing to run. The frontend verification (lint, tsc, 514 tests, build) is recorded in PR #22 and in the completion notes.

---
_Generated by [Claude Code](https://claude.ai/code/session_016kQf6eFKjTTZESXU8G52KS)_