### PR TITLE
feat: add savings goals backend foundation (item 070a)

### DIFF
--- a/product/STATE.md
+++ b/product/STATE.md
@@ -6,7 +6,7 @@
 > `CHANGELOG.md` (generated — never hand-edit), and `.claude/thoughts/` in
 > both repos for engineering research and plans.
 
-**Last updated:** 2026-06-23 (item 060 — near-real-time cross-device refresh)
+**Last updated:** 2026-06-24 (item 070a — savings-goals backend foundation)
 
 ## What Balance is
 
@@ -82,15 +82,38 @@ in the item 015 review; focused charts that aid the monthly routine are welcome.
 - **TodoList** (1:1 with budget; created on lock, deleted on unlock) →
   **TodoItem** — `TRANSFER` (from → to account) or `PAYMENT` (from account),
   status `PENDING|COMPLETED`, completedAt.
+- **SavingsGoal** (item 070a) — name, optional targetAmount, optional endDate,
+  status `ACTIVE|ARCHIVED`, archivedAt. Soft delete. "Completed" is derived
+  (allocated ≥ target), not stored.
+- **GoalAllocation** — earmark of a bank account's `currentBalance` for a goal
+  (`amount > 0`); at most one active row per `(goal, account)` — adjusted, not
+  duplicated. No soft delete: removed (hard-deleted) when set to zero or on
+  archive. Invariant: an account's total active allocations may never exceed
+  its `currentBalance`. Allocations do **not** move money (except archive with
+  `releaseToBalance=true`).
+- **GoalAllocationChange** — append-only ledger (mirrors `BalanceHistory`):
+  signed `changeAmount`, `resultingAmount`, `source`
+  `MANUAL|BUDGET_LOCK|BALANCE_REALLOCATION|ARCHIVE`. Written on every
+  allocation change; preserved across archiving and removal.
 
-Money is `BigDecimal` / `NUMERIC(19,2)` everywhere. Flyway migrations V1–V4
-(V4 dropped the deprecated `last_used_date` column).
+Money is `BigDecimal` / `NUMERIC(19,2)` everywhere. Flyway migrations V1–V5
+(V4 dropped the deprecated `last_used_date` column; V5 added the savings-goals
+tables).
 
 ## API surface (summary — details in Swagger)
 
 - `/api/bank-accounts` — POST, GET (includes totalBalance); `/{id}` PUT,
   DELETE; `/{id}/balance` POST (manual update); `/{id}/balance-history` GET
-  (paginated).
+  (paginated). `BankAccountResponse` now also carries `allocatedAmount` /
+  `unallocatedAmount` (additive, item 070a).
+- `/api/savings-goals` (item 070a) — POST (optional seed allocations from
+  accounts' unallocated money), GET (active goals with per-goal summary:
+  totalAllocated, progress, backing accounts; archived excluded); `/{id}` GET
+  (per-account breakdown), PUT (name/target/endDate); `/{id}/history` GET
+  (allocation-change ledger, newest first, available for archived goals);
+  `/{id}/allocations` POST (set an account's earmark; zero removes it);
+  `/{id}/archive` POST (`releaseToBalance` boolean — frees allocations, and
+  when true also reduces backing balances with `AUTOMATIC` balance-history).
 - `/api/budgets` — POST, GET (with totals); `/{id}` GET, DELETE; `/{id}/lock`
   PUT; `/{id}/unlock` PUT; `/{budgetId}/income|expenses|savings` POST and
   `…/{itemId}` PUT, DELETE; `/{budgetId}/todo-list` GET;
@@ -165,12 +188,12 @@ Specs live directly in `product/` (filename `NNN-slug.md`, lowest number =
 highest priority). Item 015 scoped six raw feature ideas into these; priority
 order reflects the maintainer's item 015 review (PR preview image first):
 
-- `070a–070e` **savings goals** (split: backend foundation → goals pages →
+- `070b–070e` **savings goals** (remaining parts: goals pages →
   budget linking on lock → manual-balance reallocation → progress/predictions).
-  Sizeable new domain — `070a` is the gate. `070a` now includes an append-only
-  allocation-history ledger and an archive option that can release allocations
-  back to account balances; `070e` adds progress visualizations (charts are in
-  scope — see the non-goals note above).
+  `070a` (backend foundation: entities, allocation ledger + append-only
+  history, CRUD, archive-with-release) is **done** (2026-06-24) — `070b` is the
+  next gate. `070e` adds progress visualizations (charts are in scope — see the
+  non-goals note above).
 
 ## Recently completed
 
@@ -179,6 +202,7 @@ order reflects the maintainer's item 015 review (PR preview image first):
 
 | Date | Item | Repos |
 |---|---|---|
+| 2026-06-24 | Savings-goals backend foundation: entities, allocation ledger + history, CRUD, archive (item 070a) | backend |
 | 2026-06-23 | Near-real-time cross-device refresh via React Query polling (item 060) | frontend, backend (bookkeeping) |
 | 2026-06-23 | Clean up CI/preview workflows + tighten agent prompts (item 055) | backend (CI+docs), frontend (CI) |
 | 2026-06-23 | Tighten budget wizard quick-add card density (item 050) | frontend, backend (bookkeeping) |

--- a/product/done/070a-savings-goals-backend-foundation.md
+++ b/product/done/070a-savings-goals-backend-foundation.md
@@ -165,3 +165,31 @@ choice in the PR.
   invariant stays front-of-mind.
 - The `GoalAllocationChange` design intentionally mirrors `BalanceHistory`
   (per-entity, append-only, `source` enum) so it's familiar and easy to query.
+
+## Completion notes
+
+**Completed:** 2026-06-24 · **PR:** balance-backend (branch `claude/youthful-hamilton-mvvsdd`)
+
+Backend-only foundation for the savings-goals epic. All acceptance criteria met; full suite green (345 tests, +19 new in `SavingsGoalIntegrationTest`).
+
+### What shipped
+- Entities `SavingsGoal`, `GoalAllocation`, `GoalAllocationChange` (+ enums `GoalStatus`, `GoalAllocationChangeSource`), Flyway `V5__add_savings_goals.sql` (additive — three new tables, FKs, indexes, unique `(savings_goal_id, bank_account_id)`).
+- 3-layer wiring: repositories, `SavingsGoalDtos`, `SavingsGoalExtensions`, `IDataService`/`DataService`, `IDomainService`/`DomainService`, `SavingsGoalController`.
+- Endpoints: `POST /api/savings-goals` (optional seed allocations), `GET /api/savings-goals` (active only, with summary), `GET /{id}`, `GET /{id}/history` (newest first, archived included), `PUT /{id}`, `POST /{id}/allocations`, `POST /{id}/archive`.
+- New exceptions via `GlobalExceptionHandler`: `SavingsGoalNotFoundException` (404), `SavingsGoalArchivedException` (400), `InsufficientUnallocatedFundsException` (409).
+
+### Interpretation decisions
+- **Unallocated figures:** chose the spec's preferred option — additive fields `allocatedAmount` / `unallocatedAmount` on `BankAccountResponse` (backward compatible; the accounts page wants them). The list endpoint computes them with one grouped sum query; create/update compute per-account.
+- **Allocation amount is absolute (a set, not a delta).** `POST /{id}/allocations` sets the account's earmark to the given amount; `0` removes the allocation. Mirrors the "adjust rather than duplicate" rule. A no-op (unchanged amount) writes no history row.
+- **`GoalAllocation` has no soft delete** — it is current-state; removal is a hard delete. The append-only `GoalAllocationChange` ledger is the history of record and survives archiving and removal.
+- **Invariant** (`sum(active allocations on account) ≤ currentBalance`) enforced in `DomainService.applyAllocation` and returns **409 Conflict**.
+- **Archive** rejects already-archived goals (400); `releaseToBalance=true` reduces each backing account's balance and writes an `AUTOMATIC` `BalanceHistory` row atomically; `false` leaves balances untouched. Both record `ARCHIVE` ledger rows. Empty/absent archive body defaults to `releaseToBalance=false`.
+- Mutations (update/allocate/archive) are rejected on archived goals; `GET /{id}` and `/{id}/history` work for archived goals.
+
+### Limitations / follow-ups (not in 070a scope)
+- `getAllSavingsGoals` fetches allocations per goal (N+1). Dataset is a household's handful of goals; left simple. Batch later if it ever matters.
+- Bank-account deletion is not yet allocation-aware (an account with active allocations can still be soft-deleted, orphaning allocation rows). Out of scope here; worth a guard in a later part.
+- No allocation-count cap or end-date validation beyond `targetAmount > 0`.
+
+### Verification
+- Test image note: Docker Hub / ECR layer blobs (CloudFront) are blocked by the egress policy in this environment; pulled `postgres:15-alpine` via `mirror.gcr.io` and tagged it locally, and ran with `TESTCONTAINERS_RYUK_DISABLED=true` (ryuk image is likewise blocked). `./mvnw test` → `Tests run: 345, Failures: 0, Errors: 0` BUILD SUCCESS.

--- a/src/main/java/org/example/axelnyman/main/api/endpoints/SavingsGoalController.java
+++ b/src/main/java/org/example/axelnyman/main/api/endpoints/SavingsGoalController.java
@@ -1,0 +1,108 @@
+package org.example.axelnyman.main.api.endpoints;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.example.axelnyman.main.domain.abstracts.IDomainService;
+import org.example.axelnyman.main.domain.dtos.SavingsGoalDtos.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/savings-goals")
+@Tag(name = "Savings Goals", description = "Savings goals and account allocation endpoints")
+public class SavingsGoalController {
+
+    private final IDomainService domainService;
+
+    public SavingsGoalController(IDomainService domainService) {
+        this.domainService = domainService;
+    }
+
+    @PostMapping
+    @Operation(summary = "Create savings goal", description = "Create a savings goal, optionally seeding allocations from accounts' unallocated money")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Savings goal created successfully"),
+            @ApiResponse(responseCode = "404", description = "Seed allocation references a missing bank account"),
+            @ApiResponse(responseCode = "409", description = "Seed allocation exceeds an account's unallocated balance")
+    })
+    public ResponseEntity<SavingsGoalResponse> createSavingsGoal(@Valid @RequestBody CreateSavingsGoalRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(domainService.createSavingsGoal(request));
+    }
+
+    @GetMapping
+    @Operation(summary = "Get active savings goals", description = "Retrieve all active savings goals with per-goal allocation summary; archived goals excluded")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Savings goals retrieved successfully")
+    })
+    public ResponseEntity<SavingsGoalListResponse> getAllSavingsGoals() {
+        return ResponseEntity.ok(domainService.getAllSavingsGoals());
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Get savings goal", description = "Retrieve a savings goal with its per-account allocation breakdown")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Savings goal retrieved successfully"),
+            @ApiResponse(responseCode = "404", description = "Savings goal not found")
+    })
+    public ResponseEntity<SavingsGoalResponse> getSavingsGoal(@PathVariable UUID id) {
+        return ResponseEntity.ok(domainService.getSavingsGoal(id));
+    }
+
+    @GetMapping("/{id}/history")
+    @Operation(summary = "Get allocation history", description = "Retrieve the append-only allocation change history (newest first); available for archived goals too")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "History retrieved successfully"),
+            @ApiResponse(responseCode = "404", description = "Savings goal not found")
+    })
+    public ResponseEntity<GoalAllocationHistoryResponse> getSavingsGoalHistory(@PathVariable UUID id) {
+        return ResponseEntity.ok(domainService.getSavingsGoalHistory(id));
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Update savings goal", description = "Edit a goal's name, target amount, and end date")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Savings goal updated successfully"),
+            @ApiResponse(responseCode = "400", description = "Validation error or goal is archived"),
+            @ApiResponse(responseCode = "404", description = "Savings goal not found")
+    })
+    public ResponseEntity<SavingsGoalResponse> updateSavingsGoal(
+            @PathVariable UUID id,
+            @Valid @RequestBody UpdateSavingsGoalRequest request) {
+        return ResponseEntity.ok(domainService.updateSavingsGoal(id, request));
+    }
+
+    @PostMapping("/{id}/allocations")
+    @Operation(summary = "Allocate to goal", description = "Set the amount of an account's balance earmarked for the goal; zero removes the allocation")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Allocation updated successfully"),
+            @ApiResponse(responseCode = "400", description = "Validation error or goal is archived"),
+            @ApiResponse(responseCode = "404", description = "Savings goal or bank account not found"),
+            @ApiResponse(responseCode = "409", description = "Allocation exceeds the account's unallocated balance")
+    })
+    public ResponseEntity<SavingsGoalResponse> allocateToGoal(
+            @PathVariable UUID id,
+            @Valid @RequestBody AllocateRequest request) {
+        return ResponseEntity.ok(domainService.allocateToGoal(id, request));
+    }
+
+    @PostMapping("/{id}/archive")
+    @Operation(summary = "Archive savings goal", description = "Archive a goal, freeing its allocations; with releaseToBalance=true also reduces backing account balances")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Savings goal archived successfully"),
+            @ApiResponse(responseCode = "400", description = "Goal is already archived"),
+            @ApiResponse(responseCode = "404", description = "Savings goal not found")
+    })
+    public ResponseEntity<SavingsGoalResponse> archiveSavingsGoal(
+            @PathVariable UUID id,
+            @RequestBody(required = false) ArchiveRequest request) {
+        return ResponseEntity.ok(domainService.archiveSavingsGoal(
+                id, request != null ? request : new ArchiveRequest(false)));
+    }
+}

--- a/src/main/java/org/example/axelnyman/main/domain/abstracts/IDataService.java
+++ b/src/main/java/org/example/axelnyman/main/domain/abstracts/IDataService.java
@@ -8,7 +8,10 @@ import org.example.axelnyman.main.domain.model.BudgetExpense;
 import org.example.axelnyman.main.domain.model.BudgetIncome;
 import org.example.axelnyman.main.domain.model.BudgetSavings;
 import org.example.axelnyman.main.domain.model.BudgetStatus;
+import org.example.axelnyman.main.domain.model.GoalAllocation;
+import org.example.axelnyman.main.domain.model.GoalAllocationChange;
 import org.example.axelnyman.main.domain.model.RecurringExpense;
+import org.example.axelnyman.main.domain.model.SavingsGoal;
 import org.example.axelnyman.main.domain.model.TodoItem;
 import org.example.axelnyman.main.domain.model.TodoList;
 import org.springframework.data.domain.Page;
@@ -139,4 +142,32 @@ public interface IDataService {
     void deleteBalanceHistoryByBudgetId(UUID budgetId);
 
     List<Budget> findLockedBudgetsUsingRecurringExpense(UUID recurringExpenseId, UUID excludeBudgetId);
+
+    // Bank Account batch lookup
+    List<BankAccount> getBankAccountsByIds(List<UUID> ids);
+
+    // Savings Goal operations (item 070a)
+    SavingsGoal saveSavingsGoal(SavingsGoal savingsGoal);
+
+    Optional<SavingsGoal> getSavingsGoalById(UUID id);
+
+    List<SavingsGoal> getActiveSavingsGoals();
+
+    // Goal Allocation operations (item 070a)
+    GoalAllocation saveGoalAllocation(GoalAllocation goalAllocation);
+
+    void deleteGoalAllocation(GoalAllocation goalAllocation);
+
+    Optional<GoalAllocation> getGoalAllocation(UUID savingsGoalId, UUID bankAccountId);
+
+    List<GoalAllocation> getGoalAllocationsByGoalId(UUID savingsGoalId);
+
+    BigDecimal sumAllocationsByBankAccountId(UUID bankAccountId);
+
+    List<Object[]> sumAllocationsGroupedByBankAccount();
+
+    // Goal Allocation Change history operations (item 070a)
+    GoalAllocationChange saveGoalAllocationChange(GoalAllocationChange change);
+
+    List<GoalAllocationChange> getGoalAllocationChangesByGoalId(UUID savingsGoalId);
 }

--- a/src/main/java/org/example/axelnyman/main/domain/abstracts/IDomainService.java
+++ b/src/main/java/org/example/axelnyman/main/domain/abstracts/IDomainService.java
@@ -4,6 +4,7 @@ import org.example.axelnyman.main.domain.dtos.BalanceHistoryDtos.*;
 import org.example.axelnyman.main.domain.dtos.BankAccountDtos.*;
 import org.example.axelnyman.main.domain.dtos.BudgetDtos.*;
 import org.example.axelnyman.main.domain.dtos.RecurringExpenseDtos.*;
+import org.example.axelnyman.main.domain.dtos.SavingsGoalDtos.*;
 import org.example.axelnyman.main.domain.dtos.TodoDtos.*;
 
 import java.util.UUID;
@@ -80,4 +81,19 @@ public interface IDomainService {
 
     // Todo Item operations (Story 28)
     TodoItemResponse updateTodoItemStatus(UUID budgetId, UUID todoItemId, UpdateTodoItemRequest request);
+
+    // Savings Goal operations (item 070a)
+    SavingsGoalResponse createSavingsGoal(CreateSavingsGoalRequest request);
+
+    SavingsGoalListResponse getAllSavingsGoals();
+
+    SavingsGoalResponse getSavingsGoal(UUID id);
+
+    GoalAllocationHistoryResponse getSavingsGoalHistory(UUID id);
+
+    SavingsGoalResponse updateSavingsGoal(UUID id, UpdateSavingsGoalRequest request);
+
+    SavingsGoalResponse allocateToGoal(UUID id, AllocateRequest request);
+
+    SavingsGoalResponse archiveSavingsGoal(UUID id, ArchiveRequest request);
 }

--- a/src/main/java/org/example/axelnyman/main/domain/dtos/BankAccountDtos.java
+++ b/src/main/java/org/example/axelnyman/main/domain/dtos/BankAccountDtos.java
@@ -29,6 +29,8 @@ public class BankAccountDtos {
             String name,
             String description,
             BigDecimal currentBalance,
+            BigDecimal allocatedAmount,
+            BigDecimal unallocatedAmount,
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {}

--- a/src/main/java/org/example/axelnyman/main/domain/dtos/SavingsGoalDtos.java
+++ b/src/main/java/org/example/axelnyman/main/domain/dtos/SavingsGoalDtos.java
@@ -1,0 +1,108 @@
+package org.example.axelnyman.main.domain.dtos;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import org.example.axelnyman.main.domain.model.GoalAllocationChangeSource;
+import org.example.axelnyman.main.domain.model.GoalStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public class SavingsGoalDtos {
+
+    public record CreateSavingsGoalRequest(
+            @NotBlank(message = "Name is required")
+            @Size(max = 255, message = "Name must be less than 255 characters")
+            String name,
+
+            @Positive(message = "Target amount must be positive")
+            BigDecimal targetAmount,
+
+            LocalDate endDate,
+
+            @Valid
+            List<SeedAllocationRequest> allocations
+    ) {}
+
+    public record SeedAllocationRequest(
+            @NotNull(message = "Bank account id is required")
+            UUID bankAccountId,
+
+            @NotNull(message = "Amount is required")
+            @Positive(message = "Amount must be positive")
+            BigDecimal amount
+    ) {}
+
+    public record UpdateSavingsGoalRequest(
+            @NotBlank(message = "Name is required")
+            @Size(max = 255, message = "Name must be less than 255 characters")
+            String name,
+
+            @Positive(message = "Target amount must be positive")
+            BigDecimal targetAmount,
+
+            LocalDate endDate
+    ) {}
+
+    public record AllocateRequest(
+            @NotNull(message = "Bank account id is required")
+            UUID bankAccountId,
+
+            @NotNull(message = "Amount is required")
+            @PositiveOrZero(message = "Amount must be zero or positive")
+            BigDecimal amount
+    ) {}
+
+    public record ArchiveRequest(
+            boolean releaseToBalance
+    ) {}
+
+    public record GoalAccountAllocationResponse(
+            UUID bankAccountId,
+            String bankAccountName,
+            BigDecimal amount
+    ) {}
+
+    public record SavingsGoalResponse(
+            UUID id,
+            String name,
+            BigDecimal targetAmount,
+            LocalDate endDate,
+            GoalStatus status,
+            BigDecimal totalAllocated,
+            BigDecimal progressPercentage,
+            boolean completed,
+            List<GoalAccountAllocationResponse> allocations,
+            LocalDateTime archivedAt,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {}
+
+    public record SavingsGoalListResponse(
+            int goalCount,
+            List<SavingsGoalResponse> goals
+    ) {}
+
+    public record GoalAllocationChangeResponse(
+            UUID id,
+            UUID bankAccountId,
+            String bankAccountName,
+            BigDecimal changeAmount,
+            BigDecimal resultingAmount,
+            GoalAllocationChangeSource source,
+            LocalDateTime createdAt
+    ) {}
+
+    public record GoalAllocationHistoryResponse(
+            UUID goalId,
+            List<GoalAllocationChangeResponse> changes
+    ) {}
+}

--- a/src/main/java/org/example/axelnyman/main/domain/extensions/BankAccountExtensions.java
+++ b/src/main/java/org/example/axelnyman/main/domain/extensions/BankAccountExtensions.java
@@ -12,11 +12,18 @@ public final class BankAccountExtensions {
     }
 
     public static BankAccountResponse toResponse(BankAccount bankAccount) {
+        return toResponse(bankAccount, BigDecimal.ZERO);
+    }
+
+    public static BankAccountResponse toResponse(BankAccount bankAccount, BigDecimal allocatedAmount) {
+        BigDecimal allocated = allocatedAmount != null ? allocatedAmount : BigDecimal.ZERO;
         return new BankAccountResponse(
                 bankAccount.getId(),
                 bankAccount.getName(),
                 bankAccount.getDescription(),
                 bankAccount.getCurrentBalance(),
+                allocated,
+                bankAccount.getCurrentBalance().subtract(allocated),
                 bankAccount.getCreatedAt(),
                 bankAccount.getUpdatedAt()
         );

--- a/src/main/java/org/example/axelnyman/main/domain/extensions/SavingsGoalExtensions.java
+++ b/src/main/java/org/example/axelnyman/main/domain/extensions/SavingsGoalExtensions.java
@@ -1,0 +1,76 @@
+package org.example.axelnyman.main.domain.extensions;
+
+import org.example.axelnyman.main.domain.dtos.SavingsGoalDtos.*;
+import org.example.axelnyman.main.domain.model.GoalAllocation;
+import org.example.axelnyman.main.domain.model.GoalAllocationChange;
+import org.example.axelnyman.main.domain.model.SavingsGoal;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public final class SavingsGoalExtensions {
+
+    private SavingsGoalExtensions() {
+        // Prevent instantiation
+    }
+
+    public static SavingsGoal toEntity(CreateSavingsGoalRequest request) {
+        return new SavingsGoal(request.name(), request.targetAmount(), request.endDate());
+    }
+
+    public static SavingsGoalResponse toResponse(SavingsGoal goal, List<GoalAllocation> allocations,
+                                                 Map<UUID, String> accountNames) {
+        BigDecimal totalAllocated = allocations.stream()
+                .map(GoalAllocation::getAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        List<GoalAccountAllocationResponse> allocationResponses = allocations.stream()
+                .map(allocation -> new GoalAccountAllocationResponse(
+                        allocation.getBankAccountId(),
+                        accountNames.get(allocation.getBankAccountId()),
+                        allocation.getAmount()))
+                .toList();
+
+        return new SavingsGoalResponse(
+                goal.getId(),
+                goal.getName(),
+                goal.getTargetAmount(),
+                goal.getEndDate(),
+                goal.getStatus(),
+                totalAllocated,
+                progressPercentage(totalAllocated, goal.getTargetAmount()),
+                isCompleted(totalAllocated, goal.getTargetAmount()),
+                allocationResponses,
+                goal.getArchivedAt(),
+                goal.getCreatedAt(),
+                goal.getUpdatedAt());
+    }
+
+    public static GoalAllocationChangeResponse toResponse(GoalAllocationChange change,
+                                                          Map<UUID, String> accountNames) {
+        return new GoalAllocationChangeResponse(
+                change.getId(),
+                change.getBankAccountId(),
+                accountNames.get(change.getBankAccountId()),
+                change.getChangeAmount(),
+                change.getResultingAmount(),
+                change.getSource(),
+                change.getCreatedAt());
+    }
+
+    private static BigDecimal progressPercentage(BigDecimal totalAllocated, BigDecimal targetAmount) {
+        if (targetAmount == null || targetAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            return null;
+        }
+        return totalAllocated
+                .multiply(BigDecimal.valueOf(100))
+                .divide(targetAmount, 2, RoundingMode.HALF_UP);
+    }
+
+    private static boolean isCompleted(BigDecimal totalAllocated, BigDecimal targetAmount) {
+        return targetAmount != null && totalAllocated.compareTo(targetAmount) >= 0;
+    }
+}

--- a/src/main/java/org/example/axelnyman/main/domain/model/GoalAllocation.java
+++ b/src/main/java/org/example/axelnyman/main/domain/model/GoalAllocation.java
@@ -1,0 +1,102 @@
+package org.example.axelnyman.main.domain.model;
+
+import jakarta.persistence.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Records how much of a bank account's current balance is earmarked for a
+ * savings goal. An earmark over the existing balance, not money movement.
+ * At most one active allocation exists per (goal, account) pair — adjusting
+ * the amount rather than creating duplicates. Removed (hard-deleted) when the
+ * amount reaches zero or the goal is archived; the append-only
+ * {@link GoalAllocationChange} ledger preserves the history.
+ */
+@Entity
+@Table(name = "goal_allocations")
+@EntityListeners(AuditingEntityListener.class)
+public final class GoalAllocation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private UUID savingsGoalId;
+
+    @Column(nullable = false)
+    private UUID bankAccountId;
+
+    @Column(nullable = false, precision = 19, scale = 2)
+    private BigDecimal amount;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    public GoalAllocation() {
+    }
+
+    public GoalAllocation(UUID savingsGoalId, UUID bankAccountId, BigDecimal amount) {
+        this.savingsGoalId = savingsGoalId;
+        this.bankAccountId = bankAccountId;
+        this.amount = amount;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getSavingsGoalId() {
+        return savingsGoalId;
+    }
+
+    public void setSavingsGoalId(UUID savingsGoalId) {
+        this.savingsGoalId = savingsGoalId;
+    }
+
+    public UUID getBankAccountId() {
+        return bankAccountId;
+    }
+
+    public void setBankAccountId(UUID bankAccountId) {
+        this.bankAccountId = bankAccountId;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/org/example/axelnyman/main/domain/model/GoalAllocationChange.java
+++ b/src/main/java/org/example/axelnyman/main/domain/model/GoalAllocationChange.java
@@ -1,0 +1,114 @@
+package org.example.axelnyman.main.domain.model;
+
+import jakarta.persistence.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Append-only ledger of every change to a {@link GoalAllocation} over time.
+ * Mirrors {@link BalanceHistory}: per-entity, immutable, with a {@code source}
+ * enum. Written on every allocation create/increase/reduce/remove and never
+ * updated or deleted — it survives goal archiving so historical saving data is
+ * preserved for future statistics.
+ */
+@Entity
+@Table(name = "goal_allocation_changes")
+@EntityListeners(AuditingEntityListener.class)
+public final class GoalAllocationChange {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private UUID savingsGoalId;
+
+    @Column(nullable = false)
+    private UUID bankAccountId;
+
+    @Column(nullable = false, precision = 19, scale = 2)
+    private BigDecimal changeAmount;
+
+    @Column(nullable = false, precision = 19, scale = 2)
+    private BigDecimal resultingAmount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private GoalAllocationChangeSource source;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public GoalAllocationChange() {
+    }
+
+    public GoalAllocationChange(UUID savingsGoalId, UUID bankAccountId, BigDecimal changeAmount,
+                                BigDecimal resultingAmount, GoalAllocationChangeSource source) {
+        this.savingsGoalId = savingsGoalId;
+        this.bankAccountId = bankAccountId;
+        this.changeAmount = changeAmount;
+        this.resultingAmount = resultingAmount;
+        this.source = source;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getSavingsGoalId() {
+        return savingsGoalId;
+    }
+
+    public void setSavingsGoalId(UUID savingsGoalId) {
+        this.savingsGoalId = savingsGoalId;
+    }
+
+    public UUID getBankAccountId() {
+        return bankAccountId;
+    }
+
+    public void setBankAccountId(UUID bankAccountId) {
+        this.bankAccountId = bankAccountId;
+    }
+
+    public BigDecimal getChangeAmount() {
+        return changeAmount;
+    }
+
+    public void setChangeAmount(BigDecimal changeAmount) {
+        this.changeAmount = changeAmount;
+    }
+
+    public BigDecimal getResultingAmount() {
+        return resultingAmount;
+    }
+
+    public void setResultingAmount(BigDecimal resultingAmount) {
+        this.resultingAmount = resultingAmount;
+    }
+
+    public GoalAllocationChangeSource getSource() {
+        return source;
+    }
+
+    public void setSource(GoalAllocationChangeSource source) {
+        this.source = source;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/org/example/axelnyman/main/domain/model/GoalAllocationChangeSource.java
+++ b/src/main/java/org/example/axelnyman/main/domain/model/GoalAllocationChangeSource.java
@@ -1,0 +1,8 @@
+package org.example.axelnyman.main.domain.model;
+
+public enum GoalAllocationChangeSource {
+    MANUAL,
+    BUDGET_LOCK,
+    BALANCE_REALLOCATION,
+    ARCHIVE
+}

--- a/src/main/java/org/example/axelnyman/main/domain/model/GoalStatus.java
+++ b/src/main/java/org/example/axelnyman/main/domain/model/GoalStatus.java
@@ -1,0 +1,6 @@
+package org.example.axelnyman.main.domain.model;
+
+public enum GoalStatus {
+    ACTIVE,
+    ARCHIVED
+}

--- a/src/main/java/org/example/axelnyman/main/domain/model/SavingsGoal.java
+++ b/src/main/java/org/example/axelnyman/main/domain/model/SavingsGoal.java
@@ -1,0 +1,130 @@
+package org.example.axelnyman.main.domain.model;
+
+import jakarta.persistence.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "savings_goals")
+@EntityListeners(AuditingEntityListener.class)
+public final class SavingsGoal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(precision = 19, scale = 2)
+    private BigDecimal targetAmount;
+
+    @Column
+    private LocalDate endDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private GoalStatus status;
+
+    @Column(name = "archived_at")
+    private LocalDateTime archivedAt;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public SavingsGoal() {
+    }
+
+    public SavingsGoal(String name, BigDecimal targetAmount, LocalDate endDate) {
+        this.name = name;
+        this.targetAmount = targetAmount;
+        this.endDate = endDate;
+        this.status = GoalStatus.ACTIVE;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public BigDecimal getTargetAmount() {
+        return targetAmount;
+    }
+
+    public void setTargetAmount(BigDecimal targetAmount) {
+        this.targetAmount = targetAmount;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    public GoalStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(GoalStatus status) {
+        this.status = status;
+    }
+
+    public LocalDateTime getArchivedAt() {
+        return archivedAt;
+    }
+
+    public void setArchivedAt(LocalDateTime archivedAt) {
+        this.archivedAt = archivedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public LocalDateTime getDeletedAt() {
+        return deletedAt;
+    }
+
+    public void setDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+}

--- a/src/main/java/org/example/axelnyman/main/domain/services/DomainService.java
+++ b/src/main/java/org/example/axelnyman/main/domain/services/DomainService.java
@@ -6,6 +6,7 @@ import org.example.axelnyman.main.domain.dtos.BalanceHistoryDtos.*;
 import org.example.axelnyman.main.domain.dtos.BankAccountDtos.*;
 import org.example.axelnyman.main.domain.dtos.BudgetDtos.*;
 import org.example.axelnyman.main.domain.dtos.RecurringExpenseDtos.*;
+import org.example.axelnyman.main.domain.dtos.SavingsGoalDtos.*;
 import org.example.axelnyman.main.domain.dtos.TodoDtos.*;
 import org.example.axelnyman.main.domain.extensions.BalanceHistoryExtensions;
 import org.example.axelnyman.main.domain.extensions.BankAccountExtensions;
@@ -14,11 +15,17 @@ import org.example.axelnyman.main.domain.extensions.BudgetExtensions;
 import org.example.axelnyman.main.domain.extensions.BudgetIncomeExtensions;
 import org.example.axelnyman.main.domain.extensions.BudgetSavingsExtensions;
 import org.example.axelnyman.main.domain.extensions.RecurringExpenseExtensions;
+import org.example.axelnyman.main.domain.extensions.SavingsGoalExtensions;
 import org.example.axelnyman.main.domain.extensions.TodoExtensions;
 import org.example.axelnyman.main.domain.model.BalanceHistory;
 import org.example.axelnyman.main.domain.model.BalanceHistorySource;
 import org.example.axelnyman.main.domain.model.BankAccount;
 import org.example.axelnyman.main.domain.model.Budget;
+import org.example.axelnyman.main.domain.model.GoalAllocation;
+import org.example.axelnyman.main.domain.model.GoalAllocationChange;
+import org.example.axelnyman.main.domain.model.GoalAllocationChangeSource;
+import org.example.axelnyman.main.domain.model.GoalStatus;
+import org.example.axelnyman.main.domain.model.SavingsGoal;
 import org.example.axelnyman.main.domain.model.BudgetExpense;
 import org.example.axelnyman.main.domain.model.BudgetIncome;
 import org.example.axelnyman.main.domain.model.BudgetSavings;
@@ -44,7 +51,10 @@ import org.example.axelnyman.main.shared.exceptions.DuplicateBudgetException;
 import org.example.axelnyman.main.shared.exceptions.DuplicateRecurringExpenseException;
 import org.example.axelnyman.main.shared.exceptions.FutureDateException;
 import org.example.axelnyman.main.shared.exceptions.InvalidYearException;
+import org.example.axelnyman.main.shared.exceptions.InsufficientUnallocatedFundsException;
 import org.example.axelnyman.main.shared.exceptions.NotMostRecentBudgetException;
+import org.example.axelnyman.main.shared.exceptions.SavingsGoalArchivedException;
+import org.example.axelnyman.main.shared.exceptions.SavingsGoalNotFoundException;
 import org.example.axelnyman.main.shared.exceptions.TodoItemNotFoundException;
 import org.example.axelnyman.main.shared.exceptions.TodoListNotFoundException;
 import org.example.axelnyman.main.shared.exceptions.UnlockedBudgetExistsException;
@@ -105,9 +115,13 @@ public class DomainService implements IDomainService {
                 .map(BankAccount::getCurrentBalance)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
 
+        Map<UUID, BigDecimal> allocatedByAccount = dataService.sumAllocationsGroupedByBankAccount().stream()
+                .collect(Collectors.toMap(row -> (UUID) row[0], row -> (BigDecimal) row[1]));
+
         List<BankAccountResponse> accountResponses = accounts.stream()
                 .sorted(Comparator.comparing(BankAccount::getName))
-                .map(BankAccountExtensions::toResponse)
+                .map(account -> BankAccountExtensions.toResponse(
+                        account, allocatedByAccount.getOrDefault(account.getId(), BigDecimal.ZERO)))
                 .toList();
 
         return new BankAccountListResponse(totalBalance, accounts.size(), accountResponses);
@@ -139,7 +153,8 @@ public class DomainService implements IDomainService {
         // Save (updatedAt auto-updated by JPA auditing)
         BankAccount updatedAccount = dataService.saveBankAccount(account);
 
-        return BankAccountExtensions.toResponse(updatedAccount);
+        return BankAccountExtensions.toResponse(updatedAccount,
+                dataService.sumAllocationsByBankAccountId(id));
     }
 
     @Override
@@ -1148,5 +1163,172 @@ public class DomainService implements IDomainService {
 
         // Return mapped DTO
         return TodoExtensions.toItemResponse(updatedTodoItem, fromAccount, toAccount);
+    }
+
+    // ==================== Savings Goals (item 070a) ====================
+
+    @Override
+    @Transactional
+    public SavingsGoalResponse createSavingsGoal(CreateSavingsGoalRequest request) {
+        SavingsGoal goal = dataService.saveSavingsGoal(SavingsGoalExtensions.toEntity(request));
+
+        if (request.allocations() != null) {
+            for (SeedAllocationRequest seed : request.allocations()) {
+                applyAllocation(goal.getId(), requireActiveAccount(seed.bankAccountId()),
+                        seed.amount(), GoalAllocationChangeSource.MANUAL);
+            }
+        }
+
+        return buildGoalResponse(goal);
+    }
+
+    @Override
+    public SavingsGoalListResponse getAllSavingsGoals() {
+        List<SavingsGoalResponse> goals = dataService.getActiveSavingsGoals().stream()
+                .map(this::buildGoalResponse)
+                .toList();
+        return new SavingsGoalListResponse(goals.size(), goals);
+    }
+
+    @Override
+    public SavingsGoalResponse getSavingsGoal(UUID id) {
+        return buildGoalResponse(requireGoal(id));
+    }
+
+    @Override
+    public GoalAllocationHistoryResponse getSavingsGoalHistory(UUID id) {
+        SavingsGoal goal = requireGoal(id);
+
+        List<GoalAllocationChange> changes = dataService.getGoalAllocationChangesByGoalId(goal.getId());
+        Map<UUID, String> accountNames = accountNames(changes.stream()
+                .map(GoalAllocationChange::getBankAccountId).distinct().toList());
+
+        return new GoalAllocationHistoryResponse(goal.getId(), changes.stream()
+                .map(change -> SavingsGoalExtensions.toResponse(change, accountNames))
+                .toList());
+    }
+
+    @Override
+    @Transactional
+    public SavingsGoalResponse updateSavingsGoal(UUID id, UpdateSavingsGoalRequest request) {
+        SavingsGoal goal = requireActiveGoal(id);
+        goal.setName(request.name());
+        goal.setTargetAmount(request.targetAmount());
+        goal.setEndDate(request.endDate());
+        return buildGoalResponse(dataService.saveSavingsGoal(goal));
+    }
+
+    @Override
+    @Transactional
+    public SavingsGoalResponse allocateToGoal(UUID id, AllocateRequest request) {
+        SavingsGoal goal = requireActiveGoal(id);
+        applyAllocation(goal.getId(), requireActiveAccount(request.bankAccountId()),
+                request.amount(), GoalAllocationChangeSource.MANUAL);
+        return buildGoalResponse(goal);
+    }
+
+    @Override
+    @Transactional
+    public SavingsGoalResponse archiveSavingsGoal(UUID id, ArchiveRequest request) {
+        SavingsGoal goal = requireActiveGoal(id);
+
+        for (GoalAllocation allocation : dataService.getGoalAllocationsByGoalId(goal.getId())) {
+            BigDecimal freed = allocation.getAmount();
+
+            if (request.releaseToBalance()) {
+                BankAccount account = requireActiveAccount(allocation.getBankAccountId());
+                BigDecimal newBalance = account.getCurrentBalance().subtract(freed);
+                account.setCurrentBalance(newBalance);
+                dataService.saveBankAccount(account);
+                dataService.saveBalanceHistory(new BalanceHistory(
+                        account.getId(), newBalance, freed.negate(),
+                        "Released to balance on archiving goal: " + goal.getName(),
+                        BalanceHistorySource.AUTOMATIC, null, LocalDate.now()));
+            }
+
+            dataService.saveGoalAllocationChange(new GoalAllocationChange(
+                    goal.getId(), allocation.getBankAccountId(), freed.negate(), BigDecimal.ZERO,
+                    GoalAllocationChangeSource.ARCHIVE));
+            dataService.deleteGoalAllocation(allocation);
+        }
+
+        goal.setStatus(GoalStatus.ARCHIVED);
+        goal.setArchivedAt(LocalDateTime.now());
+        return buildGoalResponse(dataService.saveSavingsGoal(goal));
+    }
+
+    /**
+     * Sets an account's allocation to a goal to an absolute {@code newAmount},
+     * enforcing the per-account invariant (active allocations may not exceed the
+     * account's balance) and appending a {@link GoalAllocationChange} ledger row.
+     * Setting the amount to zero removes the allocation. A no-op change writes
+     * nothing.
+     */
+    private void applyAllocation(UUID goalId, BankAccount account, BigDecimal newAmount,
+                                 GoalAllocationChangeSource source) {
+        Optional<GoalAllocation> existing = dataService.getGoalAllocation(goalId, account.getId());
+        BigDecimal oldAmount = existing.map(GoalAllocation::getAmount).orElse(BigDecimal.ZERO);
+        BigDecimal changeAmount = newAmount.subtract(oldAmount);
+
+        if (changeAmount.compareTo(BigDecimal.ZERO) == 0) {
+            return;
+        }
+
+        // sumAllocationsByBankAccountId already includes oldAmount, so the
+        // projected total after this change is currentSum + changeAmount.
+        BigDecimal projectedTotal = dataService.sumAllocationsByBankAccountId(account.getId()).add(changeAmount);
+        if (projectedTotal.compareTo(account.getCurrentBalance()) > 0) {
+            throw new InsufficientUnallocatedFundsException(
+                    "Allocation would exceed the unallocated balance of account: " + account.getName());
+        }
+
+        if (newAmount.compareTo(BigDecimal.ZERO) == 0) {
+            existing.ifPresent(dataService::deleteGoalAllocation);
+        } else if (existing.isPresent()) {
+            existing.get().setAmount(newAmount);
+            dataService.saveGoalAllocation(existing.get());
+        } else {
+            dataService.saveGoalAllocation(new GoalAllocation(goalId, account.getId(), newAmount));
+        }
+
+        dataService.saveGoalAllocationChange(new GoalAllocationChange(
+                goalId, account.getId(), changeAmount, newAmount, source));
+    }
+
+    private SavingsGoalResponse buildGoalResponse(SavingsGoal goal) {
+        List<GoalAllocation> allocations = dataService.getGoalAllocationsByGoalId(goal.getId());
+        Map<UUID, String> accountNames = accountNames(allocations.stream()
+                .map(GoalAllocation::getBankAccountId).toList());
+        return SavingsGoalExtensions.toResponse(goal, allocations, accountNames);
+    }
+
+    private Map<UUID, String> accountNames(List<UUID> ids) {
+        if (ids.isEmpty()) {
+            return Map.of();
+        }
+        return dataService.getBankAccountsByIds(ids).stream()
+                .collect(Collectors.toMap(BankAccount::getId, BankAccount::getName));
+    }
+
+    private SavingsGoal requireGoal(UUID id) {
+        return dataService.getSavingsGoalById(id)
+                .orElseThrow(() -> new SavingsGoalNotFoundException("Savings goal not found with id: " + id));
+    }
+
+    private SavingsGoal requireActiveGoal(UUID id) {
+        SavingsGoal goal = requireGoal(id);
+        if (goal.getStatus() == GoalStatus.ARCHIVED) {
+            throw new SavingsGoalArchivedException("Cannot modify an archived savings goal");
+        }
+        return goal;
+    }
+
+    private BankAccount requireActiveAccount(UUID id) {
+        BankAccount account = dataService.getBankAccountById(id)
+                .orElseThrow(() -> new BankAccountNotFoundException("Bank account not found with id: " + id));
+        if (account.getDeletedAt() != null) {
+            throw new BankAccountNotFoundException("Bank account not found with id: " + id);
+        }
+        return account;
     }
 }

--- a/src/main/java/org/example/axelnyman/main/infrastructure/data/context/GoalAllocationChangeRepository.java
+++ b/src/main/java/org/example/axelnyman/main/infrastructure/data/context/GoalAllocationChangeRepository.java
@@ -1,0 +1,14 @@
+package org.example.axelnyman.main.infrastructure.data.context;
+
+import org.example.axelnyman.main.domain.model.GoalAllocationChange;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface GoalAllocationChangeRepository extends JpaRepository<GoalAllocationChange, UUID> {
+
+    List<GoalAllocationChange> findAllBySavingsGoalIdOrderByCreatedAtDesc(UUID savingsGoalId);
+}

--- a/src/main/java/org/example/axelnyman/main/infrastructure/data/context/GoalAllocationRepository.java
+++ b/src/main/java/org/example/axelnyman/main/infrastructure/data/context/GoalAllocationRepository.java
@@ -1,0 +1,26 @@
+package org.example.axelnyman.main.infrastructure.data.context;
+
+import org.example.axelnyman.main.domain.model.GoalAllocation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface GoalAllocationRepository extends JpaRepository<GoalAllocation, UUID> {
+
+    List<GoalAllocation> findAllBySavingsGoalId(UUID savingsGoalId);
+
+    Optional<GoalAllocation> findBySavingsGoalIdAndBankAccountId(UUID savingsGoalId, UUID bankAccountId);
+
+    @Query("SELECT COALESCE(SUM(ga.amount), 0) FROM GoalAllocation ga WHERE ga.bankAccountId = :bankAccountId")
+    BigDecimal sumAmountByBankAccountId(@Param("bankAccountId") UUID bankAccountId);
+
+    @Query("SELECT ga.bankAccountId, COALESCE(SUM(ga.amount), 0) FROM GoalAllocation ga GROUP BY ga.bankAccountId")
+    List<Object[]> sumAmountGroupedByBankAccount();
+}

--- a/src/main/java/org/example/axelnyman/main/infrastructure/data/context/SavingsGoalRepository.java
+++ b/src/main/java/org/example/axelnyman/main/infrastructure/data/context/SavingsGoalRepository.java
@@ -1,0 +1,15 @@
+package org.example.axelnyman.main.infrastructure.data.context;
+
+import org.example.axelnyman.main.domain.model.GoalStatus;
+import org.example.axelnyman.main.domain.model.SavingsGoal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface SavingsGoalRepository extends JpaRepository<SavingsGoal, UUID> {
+
+    List<SavingsGoal> findAllByStatusAndDeletedAtIsNullOrderByCreatedAtDesc(GoalStatus status);
+}

--- a/src/main/java/org/example/axelnyman/main/infrastructure/data/services/DataService.java
+++ b/src/main/java/org/example/axelnyman/main/infrastructure/data/services/DataService.java
@@ -8,11 +8,17 @@ import org.example.axelnyman.main.domain.model.BudgetExpense;
 import org.example.axelnyman.main.domain.model.BudgetIncome;
 import org.example.axelnyman.main.domain.model.BudgetSavings;
 import org.example.axelnyman.main.domain.model.BudgetStatus;
+import org.example.axelnyman.main.domain.model.GoalAllocation;
+import org.example.axelnyman.main.domain.model.GoalAllocationChange;
 import org.example.axelnyman.main.domain.model.RecurringExpense;
+import org.example.axelnyman.main.domain.model.SavingsGoal;
 import org.example.axelnyman.main.domain.model.TodoItem;
 import org.example.axelnyman.main.domain.model.TodoList;
 import org.example.axelnyman.main.infrastructure.data.context.BalanceHistoryRepository;
 import org.example.axelnyman.main.infrastructure.data.context.BankAccountRepository;
+import org.example.axelnyman.main.infrastructure.data.context.GoalAllocationChangeRepository;
+import org.example.axelnyman.main.infrastructure.data.context.GoalAllocationRepository;
+import org.example.axelnyman.main.infrastructure.data.context.SavingsGoalRepository;
 import org.example.axelnyman.main.infrastructure.data.context.BudgetExpenseRepository;
 import org.example.axelnyman.main.infrastructure.data.context.BudgetIncomeRepository;
 import org.example.axelnyman.main.infrastructure.data.context.BudgetRepository;
@@ -39,6 +45,9 @@ public class DataService implements IDataService {
     private final BudgetSavingsRepository budgetSavingsRepository;
     private final TodoListRepository todoListRepository;
     private final TodoItemRepository todoItemRepository;
+    private final SavingsGoalRepository savingsGoalRepository;
+    private final GoalAllocationRepository goalAllocationRepository;
+    private final GoalAllocationChangeRepository goalAllocationChangeRepository;
 
     public DataService(BankAccountRepository bankAccountRepository,
                       BalanceHistoryRepository balanceHistoryRepository,
@@ -48,7 +57,10 @@ public class DataService implements IDataService {
                       BudgetExpenseRepository budgetExpenseRepository,
                       BudgetSavingsRepository budgetSavingsRepository,
                       TodoListRepository todoListRepository,
-                      TodoItemRepository todoItemRepository) {
+                      TodoItemRepository todoItemRepository,
+                      SavingsGoalRepository savingsGoalRepository,
+                      GoalAllocationRepository goalAllocationRepository,
+                      GoalAllocationChangeRepository goalAllocationChangeRepository) {
         this.bankAccountRepository = bankAccountRepository;
         this.balanceHistoryRepository = balanceHistoryRepository;
         this.recurringExpenseRepository = recurringExpenseRepository;
@@ -58,6 +70,9 @@ public class DataService implements IDataService {
         this.budgetSavingsRepository = budgetSavingsRepository;
         this.todoListRepository = todoListRepository;
         this.todoItemRepository = todoItemRepository;
+        this.savingsGoalRepository = savingsGoalRepository;
+        this.goalAllocationRepository = goalAllocationRepository;
+        this.goalAllocationChangeRepository = goalAllocationChangeRepository;
     }
 
     @Override
@@ -339,5 +354,71 @@ public class DataService implements IDataService {
             java.util.UUID recurringExpenseId,
             java.util.UUID excludeBudgetId) {
         return budgetRepository.findLockedBudgetsUsingRecurringExpense(recurringExpenseId, excludeBudgetId);
+    }
+
+    // Bank Account batch lookup
+    @Override
+    public java.util.List<BankAccount> getBankAccountsByIds(java.util.List<java.util.UUID> ids) {
+        return bankAccountRepository.findAllById(ids);
+    }
+
+    // Savings Goal operations (item 070a)
+    @Override
+    public SavingsGoal saveSavingsGoal(SavingsGoal savingsGoal) {
+        return savingsGoalRepository.save(savingsGoal);
+    }
+
+    @Override
+    public java.util.Optional<SavingsGoal> getSavingsGoalById(java.util.UUID id) {
+        return savingsGoalRepository.findById(id)
+                .filter(goal -> goal.getDeletedAt() == null);
+    }
+
+    @Override
+    public java.util.List<SavingsGoal> getActiveSavingsGoals() {
+        return savingsGoalRepository.findAllByStatusAndDeletedAtIsNullOrderByCreatedAtDesc(
+                org.example.axelnyman.main.domain.model.GoalStatus.ACTIVE);
+    }
+
+    // Goal Allocation operations (item 070a)
+    @Override
+    public GoalAllocation saveGoalAllocation(GoalAllocation goalAllocation) {
+        return goalAllocationRepository.save(goalAllocation);
+    }
+
+    @Override
+    public void deleteGoalAllocation(GoalAllocation goalAllocation) {
+        goalAllocationRepository.delete(goalAllocation);
+    }
+
+    @Override
+    public java.util.Optional<GoalAllocation> getGoalAllocation(java.util.UUID savingsGoalId, java.util.UUID bankAccountId) {
+        return goalAllocationRepository.findBySavingsGoalIdAndBankAccountId(savingsGoalId, bankAccountId);
+    }
+
+    @Override
+    public java.util.List<GoalAllocation> getGoalAllocationsByGoalId(java.util.UUID savingsGoalId) {
+        return goalAllocationRepository.findAllBySavingsGoalId(savingsGoalId);
+    }
+
+    @Override
+    public java.math.BigDecimal sumAllocationsByBankAccountId(java.util.UUID bankAccountId) {
+        return goalAllocationRepository.sumAmountByBankAccountId(bankAccountId);
+    }
+
+    @Override
+    public java.util.List<Object[]> sumAllocationsGroupedByBankAccount() {
+        return goalAllocationRepository.sumAmountGroupedByBankAccount();
+    }
+
+    // Goal Allocation Change history operations (item 070a)
+    @Override
+    public GoalAllocationChange saveGoalAllocationChange(GoalAllocationChange change) {
+        return goalAllocationChangeRepository.save(change);
+    }
+
+    @Override
+    public java.util.List<GoalAllocationChange> getGoalAllocationChangesByGoalId(java.util.UUID savingsGoalId) {
+        return goalAllocationChangeRepository.findAllBySavingsGoalIdOrderByCreatedAtDesc(savingsGoalId);
     }
 }

--- a/src/main/java/org/example/axelnyman/main/shared/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/axelnyman/main/shared/exceptions/GlobalExceptionHandler.java
@@ -206,6 +206,27 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
+    @ExceptionHandler(SavingsGoalNotFoundException.class)
+    public ResponseEntity<Object> handleSavingsGoalNotFoundException(SavingsGoalNotFoundException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    @ExceptionHandler(SavingsGoalArchivedException.class)
+    public ResponseEntity<Object> handleSavingsGoalArchivedException(SavingsGoalArchivedException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(InsufficientUnallocatedFundsException.class)
+    public ResponseEntity<Object> handleInsufficientUnallocatedFundsException(InsufficientUnallocatedFundsException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException ex) {
         Map<String, String> errorResponse = new HashMap<>();

--- a/src/main/java/org/example/axelnyman/main/shared/exceptions/InsufficientUnallocatedFundsException.java
+++ b/src/main/java/org/example/axelnyman/main/shared/exceptions/InsufficientUnallocatedFundsException.java
@@ -1,0 +1,7 @@
+package org.example.axelnyman.main.shared.exceptions;
+
+public class InsufficientUnallocatedFundsException extends RuntimeException {
+    public InsufficientUnallocatedFundsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/example/axelnyman/main/shared/exceptions/SavingsGoalArchivedException.java
+++ b/src/main/java/org/example/axelnyman/main/shared/exceptions/SavingsGoalArchivedException.java
@@ -1,0 +1,7 @@
+package org.example.axelnyman.main.shared.exceptions;
+
+public class SavingsGoalArchivedException extends RuntimeException {
+    public SavingsGoalArchivedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/example/axelnyman/main/shared/exceptions/SavingsGoalNotFoundException.java
+++ b/src/main/java/org/example/axelnyman/main/shared/exceptions/SavingsGoalNotFoundException.java
@@ -1,0 +1,7 @@
+package org.example.axelnyman.main.shared.exceptions;
+
+public class SavingsGoalNotFoundException extends RuntimeException {
+    public SavingsGoalNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/db/migration/V5__add_savings_goals.sql
+++ b/src/main/resources/db/migration/V5__add_savings_goals.sql
@@ -1,0 +1,55 @@
+-- V5__add_savings_goals.sql
+-- Savings goals foundation (item 070a): goals, an allocation ledger over
+-- existing account balances, and an append-only allocation-change history.
+-- Additive only: the currently deployed backend starts unchanged against this schema.
+--
+-- Rollback (manual): DROP TABLE goal_allocation_changes, goal_allocations, savings_goals;
+
+-- Savings Goals
+CREATE TABLE savings_goals (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(255) NOT NULL,
+    target_amount NUMERIC(19, 2),
+    end_date DATE,
+    status VARCHAR(50) NOT NULL,
+    archived_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    deleted_at TIMESTAMP
+);
+
+-- Goal Allocations: earmark of an account's balance for a goal.
+-- At most one active allocation per (goal, account); rows are removed when the
+-- amount reaches zero or the goal is archived (history is preserved separately).
+CREATE TABLE goal_allocations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    savings_goal_id UUID NOT NULL,
+    bank_account_id UUID NOT NULL,
+    amount NUMERIC(19, 2) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    CONSTRAINT fk_goal_allocations_goal FOREIGN KEY (savings_goal_id) REFERENCES savings_goals(id),
+    CONSTRAINT fk_goal_allocations_bank_account FOREIGN KEY (bank_account_id) REFERENCES bank_accounts(id),
+    CONSTRAINT uk_goal_allocations_goal_account UNIQUE (savings_goal_id, bank_account_id)
+);
+
+-- Goal Allocation Changes: append-only history of every allocation change.
+CREATE TABLE goal_allocation_changes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    savings_goal_id UUID NOT NULL,
+    bank_account_id UUID NOT NULL,
+    change_amount NUMERIC(19, 2) NOT NULL,
+    resulting_amount NUMERIC(19, 2) NOT NULL,
+    source VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    CONSTRAINT fk_goal_allocation_changes_goal FOREIGN KEY (savings_goal_id) REFERENCES savings_goals(id),
+    CONSTRAINT fk_goal_allocation_changes_bank_account FOREIGN KEY (bank_account_id) REFERENCES bank_accounts(id)
+);
+
+-- Indexes
+CREATE INDEX idx_goal_allocations_goal ON goal_allocations(savings_goal_id);
+CREATE INDEX idx_goal_allocations_bank_account ON goal_allocations(bank_account_id);
+CREATE INDEX idx_goal_allocation_changes_goal ON goal_allocation_changes(savings_goal_id);
+CREATE INDEX idx_goal_allocation_changes_bank_account ON goal_allocation_changes(bank_account_id);
+CREATE INDEX idx_savings_goals_status ON savings_goals(status);
+CREATE INDEX idx_savings_goals_deleted ON savings_goals(deleted_at);

--- a/src/test/java/org/example/axelnyman/main/integration/SavingsGoalIntegrationTest.java
+++ b/src/test/java/org/example/axelnyman/main/integration/SavingsGoalIntegrationTest.java
@@ -1,0 +1,465 @@
+package org.example.axelnyman.main.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.axelnyman.main.domain.dtos.BankAccountDtos.CreateBankAccountRequest;
+import org.example.axelnyman.main.domain.dtos.SavingsGoalDtos.*;
+import org.example.axelnyman.main.infrastructure.data.context.BalanceHistoryRepository;
+import org.example.axelnyman.main.infrastructure.data.context.BankAccountRepository;
+import org.example.axelnyman.main.infrastructure.data.context.GoalAllocationChangeRepository;
+import org.example.axelnyman.main.infrastructure.data.context.GoalAllocationRepository;
+import org.example.axelnyman.main.infrastructure.data.context.SavingsGoalRepository;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Testcontainers
+public class SavingsGoalIntegrationTest {
+
+    @Container
+    @SuppressWarnings("resource")
+    static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgreSQLContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", postgreSQLContainer::getUsername);
+        registry.add("spring.datasource.password", postgreSQLContainer::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    }
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private SavingsGoalRepository savingsGoalRepository;
+
+    @Autowired
+    private GoalAllocationRepository goalAllocationRepository;
+
+    @Autowired
+    private GoalAllocationChangeRepository goalAllocationChangeRepository;
+
+    @Autowired
+    private BankAccountRepository bankAccountRepository;
+
+    @Autowired
+    private BalanceHistoryRepository balanceHistoryRepository;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+
+        goalAllocationChangeRepository.deleteAll();
+        goalAllocationRepository.deleteAll();
+        savingsGoalRepository.deleteAll();
+        balanceHistoryRepository.deleteAll();
+        bankAccountRepository.deleteAll();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (postgreSQLContainer != null && postgreSQLContainer.isRunning()) {
+            postgreSQLContainer.stop();
+        }
+    }
+
+    // ---------- helpers ----------
+
+    private UUID createAccount(String name, String balance) throws Exception {
+        String response = mockMvc.perform(post("/api/bank-accounts")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                        new CreateBankAccountRequest(name, null, new BigDecimal(balance)))))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return UUID.fromString(objectMapper.readTree(response).get("id").asText());
+    }
+
+    private UUID createGoal(CreateSavingsGoalRequest request) throws Exception {
+        String response = mockMvc.perform(post("/api/savings-goals")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return UUID.fromString(objectMapper.readTree(response).get("id").asText());
+    }
+
+    private void allocate(UUID goalId, UUID accountId, String amount) throws Exception {
+        mockMvc.perform(post("/api/savings-goals/" + goalId + "/allocations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new AllocateRequest(accountId, new BigDecimal(amount)))))
+                .andExpect(status().isOk());
+    }
+
+    // ---------- create ----------
+
+    @Test
+    void shouldCreateGoalWithoutAllocations() throws Exception {
+        CreateSavingsGoalRequest request = new CreateSavingsGoalRequest(
+                "Trip to Japan", new BigDecimal("20000.00"), null, null);
+
+        mockMvc.perform(post("/api/savings-goals")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.name", is("Trip to Japan")))
+                .andExpect(jsonPath("$.targetAmount", is(20000.00)))
+                .andExpect(jsonPath("$.status", is("ACTIVE")))
+                .andExpect(jsonPath("$.totalAllocated", is(0)))
+                .andExpect(jsonPath("$.completed", is(false)))
+                .andExpect(jsonPath("$.allocations", hasSize(0)));
+
+        assert savingsGoalRepository.count() == 1;
+    }
+
+    @Test
+    void shouldCreateGoalWithSeedAllocations() throws Exception {
+        UUID checking = createAccount("Checking", "1000.00");
+        UUID savings = createAccount("Savings", "500.00");
+
+        CreateSavingsGoalRequest request = new CreateSavingsGoalRequest(
+                "Buffer", new BigDecimal("2000.00"), null,
+                List.of(new SeedAllocationRequest(checking, new BigDecimal("300.00")),
+                        new SeedAllocationRequest(savings, new BigDecimal("200.00"))));
+
+        mockMvc.perform(post("/api/savings-goals")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.totalAllocated", is(500.00)))
+                .andExpect(jsonPath("$.allocations", hasSize(2)));
+
+        // Two MANUAL history rows written
+        assert goalAllocationChangeRepository.count() == 2;
+    }
+
+    // ---------- invariant ----------
+
+    @Test
+    void shouldRejectSeedAllocationExceedingBalanceAndRollBack() throws Exception {
+        UUID account = createAccount("Small", "100.00");
+
+        CreateSavingsGoalRequest request = new CreateSavingsGoalRequest(
+                "Too big", null, null,
+                List.of(new SeedAllocationRequest(account, new BigDecimal("200.00"))));
+
+        mockMvc.perform(post("/api/savings-goals")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict());
+
+        // Transaction rolled back: no goal, no allocation, no history
+        assert savingsGoalRepository.count() == 0;
+        assert goalAllocationRepository.count() == 0;
+        assert goalAllocationChangeRepository.count() == 0;
+    }
+
+    @Test
+    void shouldEnforceInvariantAcrossGoalsOnManualAllocate() throws Exception {
+        UUID account = createAccount("Shared", "1000.00");
+        UUID goalA = createGoal(new CreateSavingsGoalRequest("A", null, null, null));
+        UUID goalB = createGoal(new CreateSavingsGoalRequest("B", null, null, null));
+
+        allocate(goalA, account, "700.00");
+
+        // 700 + 400 > 1000 → rejected
+        mockMvc.perform(post("/api/savings-goals/" + goalB + "/allocations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new AllocateRequest(account, new BigDecimal("400.00")))))
+                .andExpect(status().isConflict());
+
+        // 700 + 300 == 1000 → allowed
+        allocate(goalB, account, "300.00");
+
+        assert goalAllocationRepository.sumAmountByBankAccountId(account).compareTo(new BigDecimal("1000.00")) == 0;
+    }
+
+    // ---------- allocate / adjust / zero ----------
+
+    @Test
+    void shouldAllocateAdjustAndRemoveOnZero() throws Exception {
+        UUID account = createAccount("Checking", "1000.00");
+        UUID goal = createGoal(new CreateSavingsGoalRequest("Goal", null, null, null));
+
+        allocate(goal, account, "300.00");
+        allocate(goal, account, "500.00"); // adjust upward
+        allocate(goal, account, "0.00");   // remove
+
+        // No active allocation remains, but all three changes are recorded
+        assert goalAllocationRepository.findAllBySavingsGoalId(goal).isEmpty();
+
+        mockMvc.perform(get("/api/savings-goals/" + goal))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalAllocated", is(0)))
+                .andExpect(jsonPath("$.allocations", hasSize(0)));
+
+        mockMvc.perform(get("/api/savings-goals/" + goal + "/history"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.changes", hasSize(3)))
+                // newest first: -500 resulting 0, +200 resulting 500, +300 resulting 300
+                .andExpect(jsonPath("$.changes[0].changeAmount", is(-500.00)))
+                .andExpect(jsonPath("$.changes[0].resultingAmount", is(0.0)))
+                .andExpect(jsonPath("$.changes[0].source", is("MANUAL")))
+                .andExpect(jsonPath("$.changes[2].changeAmount", is(300.00)))
+                .andExpect(jsonPath("$.changes[2].resultingAmount", is(300.00)));
+    }
+
+    @Test
+    void shouldNotWriteHistoryForNoOpAllocation() throws Exception {
+        UUID account = createAccount("Checking", "1000.00");
+        UUID goal = createGoal(new CreateSavingsGoalRequest("Goal", null, null, null));
+
+        allocate(goal, account, "0.00"); // allocate zero where none exists → no-op
+
+        assert goalAllocationChangeRepository.count() == 0;
+    }
+
+    // ---------- unallocated computation ----------
+
+    @Test
+    void shouldExposeAllocatedAndUnallocatedOnBankAccountResponse() throws Exception {
+        UUID checking = createAccount("Checking", "1000.00");
+        UUID goal = createGoal(new CreateSavingsGoalRequest("Goal", null, null, null));
+        allocate(goal, checking, "300.00");
+
+        mockMvc.perform(get("/api/bank-accounts"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accounts[0].currentBalance", is(1000.00)))
+                .andExpect(jsonPath("$.accounts[0].allocatedAmount", is(300.00)))
+                .andExpect(jsonPath("$.accounts[0].unallocatedAmount", is(700.00)));
+    }
+
+    // ---------- derived progress ----------
+
+    @Test
+    void shouldDeriveProgressAndCompletion() throws Exception {
+        UUID account = createAccount("Checking", "1000.00");
+        UUID goal = createGoal(new CreateSavingsGoalRequest("Goal", new BigDecimal("400.00"), null, null));
+
+        allocate(goal, account, "200.00");
+        mockMvc.perform(get("/api/savings-goals/" + goal))
+                .andExpect(jsonPath("$.progressPercentage", is(50.00)))
+                .andExpect(jsonPath("$.completed", is(false)));
+
+        allocate(goal, account, "500.00"); // exceeds target → completed, >100%
+        mockMvc.perform(get("/api/savings-goals/" + goal))
+                .andExpect(jsonPath("$.progressPercentage", is(125.00)))
+                .andExpect(jsonPath("$.completed", is(true)));
+    }
+
+    @Test
+    void shouldReturnNullProgressWhenNoTarget() throws Exception {
+        UUID goal = createGoal(new CreateSavingsGoalRequest("No target", null, null, null));
+
+        mockMvc.perform(get("/api/savings-goals/" + goal))
+                .andExpect(jsonPath("$.progressPercentage").doesNotExist())
+                .andExpect(jsonPath("$.completed", is(false)));
+    }
+
+    // ---------- archive: false (no balance change) ----------
+
+    @Test
+    void shouldArchiveWithoutReleasingBalance() throws Exception {
+        UUID account = createAccount("Checking", "1000.00");
+        UUID goal = createGoal(new CreateSavingsGoalRequest("Goal", null, null, null));
+        allocate(goal, account, "400.00");
+
+        mockMvc.perform(post("/api/savings-goals/" + goal + "/archive")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new ArchiveRequest(false))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", is("ARCHIVED")))
+                .andExpect(jsonPath("$.archivedAt").exists());
+
+        // Allocation freed, balance untouched, money fully unallocated again
+        assert goalAllocationRepository.findAllBySavingsGoalId(goal).isEmpty();
+        mockMvc.perform(get("/api/bank-accounts"))
+                .andExpect(jsonPath("$.accounts[0].currentBalance", is(1000.00)))
+                .andExpect(jsonPath("$.accounts[0].unallocatedAmount", is(1000.00)));
+
+        // Only the initial MANUAL balance-history row from account creation exists
+        assert balanceHistoryRepository.count() == 1;
+    }
+
+    // ---------- archive: true (release to balance) ----------
+
+    @Test
+    void shouldArchiveReleasingBalanceAndWriteBalanceHistory() throws Exception {
+        UUID account = createAccount("Checking", "1000.00");
+        UUID goal = createGoal(new CreateSavingsGoalRequest("Goal", null, null, null));
+        allocate(goal, account, "400.00");
+
+        mockMvc.perform(post("/api/savings-goals/" + goal + "/archive")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new ArchiveRequest(true))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", is("ARCHIVED")));
+
+        // Balance reduced by the freed amount; invariant preserved (unallocated unchanged)
+        mockMvc.perform(get("/api/bank-accounts"))
+                .andExpect(jsonPath("$.accounts[0].currentBalance", is(600.00)))
+                .andExpect(jsonPath("$.accounts[0].allocatedAmount", is(0)))
+                .andExpect(jsonPath("$.accounts[0].unallocatedAmount", is(600.00)));
+
+        // Initial MANUAL + one AUTOMATIC release row
+        assert balanceHistoryRepository.count() == 2;
+        assert balanceHistoryRepository.findAllByBankAccountIdOrderByChangeDateDescCreatedAtDesc(
+                account, org.springframework.data.domain.PageRequest.of(0, 10))
+                .getContent().stream()
+                .anyMatch(h -> h.getChangeAmount().compareTo(new BigDecimal("-400.00")) == 0
+                        && h.getSource().name().equals("AUTOMATIC"));
+    }
+
+    @Test
+    void shouldPreserveHistoryAfterArchiving() throws Exception {
+        UUID account = createAccount("Checking", "1000.00");
+        UUID goal = createGoal(new CreateSavingsGoalRequest("Goal", null, null, null));
+        allocate(goal, account, "400.00");
+
+        mockMvc.perform(post("/api/savings-goals/" + goal + "/archive")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new ArchiveRequest(false))))
+                .andExpect(status().isOk());
+
+        // History survives archiving and is available for the archived goal
+        mockMvc.perform(get("/api/savings-goals/" + goal + "/history"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.changes", hasSize(2)))
+                .andExpect(jsonPath("$.changes[0].source", is("ARCHIVE")))
+                .andExpect(jsonPath("$.changes[0].changeAmount", is(-400.00)))
+                .andExpect(jsonPath("$.changes[1].source", is("MANUAL")));
+    }
+
+    // ---------- list excludes archived ----------
+
+    @Test
+    void shouldExcludeArchivedGoalsFromList() throws Exception {
+        createGoal(new CreateSavingsGoalRequest("Active goal", null, null, null));
+        UUID toArchive = createGoal(new CreateSavingsGoalRequest("Archived goal", null, null, null));
+
+        mockMvc.perform(post("/api/savings-goals/" + toArchive + "/archive"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/savings-goals"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.goalCount", is(1)))
+                .andExpect(jsonPath("$.goals", hasSize(1)))
+                .andExpect(jsonPath("$.goals[0].name", is("Active goal")));
+    }
+
+    // ---------- detail breakdown ----------
+
+    @Test
+    void shouldReturnGoalWithPerAccountBreakdown() throws Exception {
+        UUID checking = createAccount("Checking", "1000.00");
+        UUID goal = createGoal(new CreateSavingsGoalRequest("Goal", null, null, null));
+        allocate(goal, checking, "250.00");
+
+        mockMvc.perform(get("/api/savings-goals/" + goal))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allocations", hasSize(1)))
+                .andExpect(jsonPath("$.allocations[0].bankAccountId", is(checking.toString())))
+                .andExpect(jsonPath("$.allocations[0].bankAccountName", is("Checking")))
+                .andExpect(jsonPath("$.allocations[0].amount", is(250.00)));
+    }
+
+    // ---------- update ----------
+
+    @Test
+    void shouldUpdateGoalDetails() throws Exception {
+        UUID goal = createGoal(new CreateSavingsGoalRequest("Old name", null, null, null));
+
+        mockMvc.perform(put("/api/savings-goals/" + goal)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                        new UpdateSavingsGoalRequest("New name", new BigDecimal("5000.00"), null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name", is("New name")))
+                .andExpect(jsonPath("$.targetAmount", is(5000.00)));
+    }
+
+    // ---------- error handling ----------
+
+    @Test
+    void shouldReturn404ForMissingGoal() throws Exception {
+        mockMvc.perform(get("/api/savings-goals/" + UUID.randomUUID()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldRejectMutationsOnArchivedGoal() throws Exception {
+        UUID account = createAccount("Checking", "1000.00");
+        UUID goal = createGoal(new CreateSavingsGoalRequest("Goal", null, null, null));
+
+        mockMvc.perform(post("/api/savings-goals/" + goal + "/archive"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(put("/api/savings-goals/" + goal)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                        new UpdateSavingsGoalRequest("x", null, null))))
+                .andExpect(status().isBadRequest());
+
+        mockMvc.perform(post("/api/savings-goals/" + goal + "/allocations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new AllocateRequest(account, new BigDecimal("10.00")))))
+                .andExpect(status().isBadRequest());
+
+        mockMvc.perform(post("/api/savings-goals/" + goal + "/archive"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturn404WhenAllocatingToMissingAccount() throws Exception {
+        UUID goal = createGoal(new CreateSavingsGoalRequest("Goal", null, null, null));
+
+        mockMvc.perform(post("/api/savings-goals/" + goal + "/allocations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                        new AllocateRequest(UUID.randomUUID(), new BigDecimal("10.00")))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldValidateRequiredGoalName() throws Exception {
+        mockMvc.perform(post("/api/savings-goals")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                        new CreateSavingsGoalRequest("", null, null, null))))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## What & why

Backend foundation for the **savings goals** epic (`070a`, part 1 of 5). The couple wants to see which money in each bank account is already "spoken for" by a goal (a trip, a buffer) versus still free to allocate. This adds the goals concept and an **allocation ledger over existing balances** — plus an append-only history that later parts (pages, budget linking, predictions) build on.

`Backlog item: 070a-savings-goals-backend-foundation`

Allocations are an **earmark**, not money movement: `GoalAllocation.amount` records how much of an account's `currentBalance` is spoken for; unallocated = `currentBalance − sum(active allocations)`. The only place this touches `currentBalance` is archive-with-`releaseToBalance=true` (symmetric: allocation and balance fall together).

## What shipped (3-layer, BankAccount template)
- **Entities:** `SavingsGoal`, `GoalAllocation`, `GoalAllocationChange` (+ enums `GoalStatus`, `GoalAllocationChangeSource`). Flyway **`V5`** — additive: three new tables, FKs, indexes, unique `(savings_goal_id, bank_account_id)`. The deployed image still starts against the new schema.
- **Endpoints** (`/api/savings-goals`, all new/additive):
  - `POST` — create, optionally seeding allocations from accounts' unallocated money
  - `GET` — active goals with per-goal summary (totalAllocated, derived progress, backing accounts); archived excluded
  - `GET /{id}` — per-account allocation breakdown
  - `GET /{id}/history` — allocation-change ledger, newest first, available for archived goals
  - `PUT /{id}` — edit name / targetAmount / endDate
  - `POST /{id}/allocations` — set an account's earmark (absolute amount; `0` removes it)
  - `POST /{id}/archive` — `releaseToBalance` boolean
- **Errors** via `GlobalExceptionHandler`: `SavingsGoalNotFoundException` (404), `SavingsGoalArchivedException` (400), `InsufficientUnallocatedFundsException` (409).

## Key interpretation decisions
- **Unallocated figures:** took the spec's *preferred* option — additive `allocatedAmount` / `unallocatedAmount` on `BankAccountResponse` (backward compatible; the accounts page wants them). List computes them with one grouped-sum query.
- **Allocation amount is absolute** (a set, not a delta); `0` removes the allocation; a no-op writes no history row.
- **`GoalAllocation` has no soft delete** — it is current-state, hard-deleted on zero/archive; the append-only `GoalAllocationChange` ledger is the history of record and survives archiving.
- **Invariant** `sum(active allocations on account) ≤ currentBalance` enforced in `DomainService.applyAllocation` → **409**.
- **Archive** rejects already-archived goals; `releaseToBalance=true` reduces each backing balance and writes an `AUTOMATIC` `BalanceHistory` row atomically; `false` leaves balances untouched. Both record `ARCHIVE` ledger rows. Absent body defaults to `false`. Mutations are rejected on archived goals; reads (detail/history) still work.

## Test evidence
`SavingsGoalIntegrationTest` adds 19 Testcontainers tests covering create (with/without seed), invariant rejection + transactional rollback, allocate/adjust/zero, no-op suppression, history written/ordered/preserved-after-archive, archive both modes (balances unchanged vs reduced + balance-history), list-excludes-archived, unallocated computation, derived progress/completion, and error paths.

```
./mvnw test  →  Tests run: 345, Failures: 0, Errors: 0, Skipped: 0   BUILD SUCCESS
```
(BankAccount 66, Budget 195, RecurringExpense 50, SavingsGoal 19, util 14, context 1 — no regressions from the `BankAccountResponse` additions.)

**Environment note:** Docker Hub / ECR layer blobs (CloudFront) are blocked by this environment's egress policy, so `postgres:15-alpine` was pulled via `mirror.gcr.io` and tagged locally, and tests ran with `TESTCONTAINERS_RYUK_DISABLED=true` (the ryuk image is likewise blocked). No source/test changes were needed for this; CI is unaffected.

## Limitations / follow-ups (out of 070a scope)
- `getAllSavingsGoals` fetches allocations per goal (N+1). Dataset is a household's handful of goals; left simple, batch later if needed.
- Bank-account deletion is not yet allocation-aware (an account with active allocations can still be soft-deleted, orphaning allocations). Worth a guard in a later part.
- No allocation-count cap; goal validation is `targetAmount > 0` only.

Out of scope by design (later parts): budget savings↔goal linking on lock (070c), manual-balance reallocation (070d), frontend pages (070b), predictions/charts (070e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkX32nTbRnWtZZ9F9y2fKC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkX32nTbRnWtZZ9F9y2fKC)_