### PR TITLE
docs: mark savings-goals frontend pages done (item 070b)

### DIFF
--- a/product/STATE.md
+++ b/product/STATE.md
@@ -6,7 +6,7 @@
 > `CHANGELOG.md` (generated — never hand-edit), and `.claude/thoughts/` in
 > both repos for engineering research and plans.
 
-**Last updated:** 2026-06-24 (item 070a — savings-goals backend foundation)
+**Last updated:** 2026-06-24 (item 070b — savings-goals frontend pages)
 
 ## What Balance is
 
@@ -145,6 +145,14 @@ tables).
   from any expense row, with one-click add (item 010).
 - `/budgets/:id/todo` — progress bar; TRANSFER/PAYMENT items with optimistic
   checkbox toggling.
+- `/goals` — card grid of active savings goals (name, allocated/target progress
+  bar, backing accounts, completed badge); "new goal" opens a create modal with
+  an optional initial allocation seeded from an account's unallocated money
+  (item 070b).
+- `/goals/:id` — goal summary + progress, per-account allocation breakdown, and
+  edit / assign-money (capped at unallocated) / archive actions. Archive offers
+  the `releaseToBalance` choice (free the earmark, or also spend it and reduce
+  backing balances). Archived goals render read-only (item 070b).
 
 ## Conventions that matter
 
@@ -188,12 +196,13 @@ Specs live directly in `product/` (filename `NNN-slug.md`, lowest number =
 highest priority). Item 015 scoped six raw feature ideas into these; priority
 order reflects the maintainer's item 015 review (PR preview image first):
 
-- `070b–070e` **savings goals** (remaining parts: goals pages →
-  budget linking on lock → manual-balance reallocation → progress/predictions).
-  `070a` (backend foundation: entities, allocation ledger + append-only
-  history, CRUD, archive-with-release) is **done** (2026-06-24) — `070b` is the
-  next gate. `070e` adds progress visualizations (charts are in scope — see the
-  non-goals note above).
+- `070c–070e` **savings goals** (remaining parts: budget-savings ↔ goal linking
+  on lock → manual-balance reallocation → progress/predictions). `070a` (backend
+  foundation) and `070b` (frontend goals pages: list, detail, create/edit/
+  assign/archive) are **done** (2026-06-24) — `070c` is the next gate. `070e`
+  adds progress visualizations (charts are in scope — see the non-goals note
+  above), including surfacing the `GoalAllocationChange` history (already
+  fetchable via `GET /{id}/history`; 070b wired the hook but no UI yet).
 
 ## Recently completed
 
@@ -202,6 +211,7 @@ order reflects the maintainer's item 015 review (PR preview image first):
 
 | Date | Item | Repos |
 |---|---|---|
+| 2026-06-24 | Savings-goals frontend pages: list, detail, create/edit/assign/archive (item 070b) | frontend, backend (bookkeeping) |
 | 2026-06-24 | Savings-goals backend foundation: entities, allocation ledger + history, CRUD, archive (item 070a) | backend |
 | 2026-06-23 | Near-real-time cross-device refresh via React Query polling (item 060) | frontend, backend (bookkeeping) |
 | 2026-06-23 | Clean up CI/preview workflows + tighten agent prompts (item 055) | backend (CI+docs), frontend (CI) |

--- a/product/done/070b-savings-goals-pages.md
+++ b/product/done/070b-savings-goals-pages.md
@@ -81,3 +81,32 @@ Add a **Goals** page reachable from the sidebar:
 
 - Depends on 070a's chosen shape for unallocated figures (account fields vs
   endpoint) — read the merged 070a before building.
+
+## Completion notes
+
+**Completed:** 2026-06-24 · **PR:** balance-frontend (branch `claude/peaceful-hamilton-n37ctb`) · bookkeeping in balance-backend (branch `claude/youthful-hamilton-n37ctb`)
+
+Frontend for the savings-goals epic, built on the merged 070a backend. All acceptance criteria met; full frontend suite green (59 files, 527 tests, +13 new across `GoalsPage.test.tsx` and `GoalDetailPage.test.tsx`). `npm run lint` (0 errors), `npx tsc --noEmit`, and `npm run build` all pass.
+
+### What shipped (frontend)
+- Sidebar "Goals" entry (Target icon); routes `/goals` and `/goals/:id` under the app layout (`routes.ts`, `App.tsx`, `Sidebar.tsx`).
+- `GoalsPage`: card grid of active goals (`GoalGrid` + `GoalCard`) with name, allocated/target progress bar, backing-account summary, "Complete" badge; loading skeletons, error state, empty state — all reusing the shared components.
+- `GoalModal` (create/edit, RHF + Zod): name, optional target, optional end date; create-only optional initial allocation from an account's unallocated money with a client-side cap (backend still enforces the invariant).
+- `GoalDetailPage`: progress summary, per-account allocation breakdown, and edit / assign-money / archive actions. Archived goals render read-only (actions hidden, "Archived" badge).
+- `AllocateModal`: manual assign — sets an account's earmark (absolute), pre-filled with the current allocation, capped at `unallocated + current earmark`; zero removes.
+- `ArchiveGoalDialog`: surfaces the 070a `releaseToBalance` choice via a plainly-phrased checkbox ("Also spend the money" → reduce backing balances; default off → just free the earmark).
+- API/data: `api/goals.ts`, `useGoals/useGoal/useGoalHistory/useCreateGoal/useUpdateGoal/useAllocateToGoal/useArchiveGoal`, `queryKeys.goals` factory. Goal mutations invalidate both goals and accounts (unallocated figures change).
+- Types: additive `allocatedAmount?` / `unallocatedAmount?` on `BankAccount` plus the savings-goal DTO types, mirroring 070a's `BankAccountResponse` and `SavingsGoalDtos`.
+
+### Interpretation decisions
+- **Unallocated source:** read 070a's additive `allocatedAmount` / `unallocatedAmount` on the accounts response (not a dedicated endpoint).
+- **Made the two new `BankAccount` fields optional** in the TS type. They are always present on `/api/bank-accounts`, but a couple of places (e.g. `TodoItemList`) build partial account objects; optional avoids fabricating allocation data there and keeps the diff additive. Goals code defaults them with `?? 0`.
+- **Assign is absolute "set" semantics** (matches the 070a `POST /{id}/allocations` contract): the field is the new earmark for that account, pre-filled with the existing amount; zero removes. Client cap = `account.unallocatedAmount + thisGoal'sCurrentEarmarkOnAccount`.
+- **Create-time seed** offers a single optional account+amount (the backend accepts a list); richer multi-account seeding deferred — manual assign on the detail page covers it.
+- **`GoalAllocationChange` history** is fetched by a hook (`useGoalHistory`) but not yet surfaced in the UI — the detail-page visualizations are 070e's scope. History/predictions intentionally out of scope here.
+
+### Deploy ordering / note
+- Frontend-only change; depends on the 070a backend being **deployed** (release-please PR balance-backend#55 merged) before this frontend is deployed, or the Goals page will 404 against production. The backend is already merged to `main`; this is a merge-ordering note for the maintainer, not a code dependency.
+
+### Not done (later parts, by design)
+- Budget-savings ↔ goal linking on lock (070c), manual-balance reallocation (070d), and progress/velocity visualizations + the allocation-history view (070e).


### PR DESCRIPTION
## What & why

Product-backlog bookkeeping for **item 070b** (savings-goals frontend pages),
which shipped in **balance-frontend#23**. Docs-only; no code changes.

- Move `product/070b-savings-goals-pages.md` → `product/done/` and append
  `## Completion notes` (what shipped, interpretation decisions, deploy-ordering
  note, deferred parts).
- Update `product/STATE.md`:
  - Add the `/goals` and `/goals/:id` pages to "Frontend pages".
  - Advance the savings-goals backlog — `070a` + `070b` done, **`070c` is now
    the next gate**; note that the `GoalAllocationChange` history is already
    fetchable and 070b wired the hook (UI in `070e`).
  - Add the `070b` row to "Recently completed".

`Backlog item: 070b-savings-goals-pages`

## Sibling PR

Feature implementation: **axel-nyman/balance-frontend#23**
(branch `claude/peaceful-hamilton-n37ctb`).

**Merge order:** this docs PR can merge any time; it does not gate the frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NrK4QfF9bGZtjVdyha3SM

---
_Generated by [Claude Code](https://claude.ai/code/session_017NrK4QfF9bGZtjVdyha3SM)_