### PR TITLE
feat: link budget savings to goals and earmark on lock (item 070c)

### DIFF
--- a/product/STATE.md
+++ b/product/STATE.md
@@ -143,7 +143,9 @@ tables; V6 added the nullable `budget_savings.savings_goal_id` FK).
   (item 040); create requires balance = 0. Recurring quick-add cards are a
   single compact row (name + amount + add) with the bank account deferred until
   the item is added — set from the template default and editable afterwards —
-  and tighter padding at `md+` so more fit on desktop (item 050).
+  and tighter padding at `md+` so more fit on desktop (item 050). The savings
+  step also has an optional per-line **Goal** selector (item 070c), so a saving
+  can be earmarked toward a goal during budget creation.
 - `/budgets/:id` — income/expenses/savings sections with add/edit/delete
   modals (UNLOCKED only); summary with balance bar; lock/unlock/delete
   actions; link to the todo page when locked. The savings add/edit modal has an
@@ -174,6 +176,10 @@ tables; V6 added the nullable `budget_savings.savings_goal_id` FK).
   expenses, todo list) background-poll every 30s (`POLL_INTERVAL` in
   `src/lib/query-config.ts`) so two open sessions stay in near-real-time sync;
   polling pauses when the tab is hidden (item 060). Reads only — no push/SSE.
+  The React Query default `staleTime` is **0** (item 070c follow-up), so every
+  navigation/mount and window focus also refetches — cheap on a two-user LAN and
+  it keeps views (e.g. goals after a budget lock) current between polls. Lock/
+  unlock additionally invalidate the goals queries directly.
 - Soft deletes everywhere; migrations are additive/backward compatible; never
   edit an applied migration; never hand-edit `CHANGELOG.md`.
 - Engineering conventions live in each repo's `CLAUDE.md` (3-layer
@@ -213,9 +219,10 @@ order reflects the maintainer's item 015 review (PR preview image first):
   `GoalAllocationChange` history (already fetchable via `GET /{id}/history`;
   070b wired the hook but no UI yet).
 
-  **Follow-up noted in 070c:** the budget **wizard** savings step does not yet
-  expose the goal selector (only the budget-detail savings modal does); linking
-  during initial budget creation is a small future item.
+  Both the budget-detail savings modal **and** the create-budget wizard savings
+  step expose the goal selector, so a saving can be linked to a goal either
+  during initial budget creation or afterwards (the wizard selector was added
+  in the 070c frontend follow-up).
 
 ## Recently completed
 

--- a/product/STATE.md
+++ b/product/STATE.md
@@ -6,7 +6,7 @@
 > `CHANGELOG.md` (generated — never hand-edit), and `.claude/thoughts/` in
 > both repos for engineering research and plans.
 
-**Last updated:** 2026-06-24 (item 070b — savings-goals frontend pages)
+**Last updated:** 2026-06-25 (item 070c — budget savings ↔ goal linking on lock)
 
 ## What Balance is
 
@@ -37,13 +37,16 @@ in the item 015 review; focused charts that aid the monthly routine are welcome.
    (TRANSFER items for the plan + PAYMENT items for manual expenses), applies
    the transfers to account balances, and writes AUTOMATIC balance-history
    entries. Recurring templates used in the budget get their last-used
-   month/year stamped, which drives their next due date.
+   month/year stamped, which drives their next due date. Any savings line
+   linked to a goal (item 070c) also earmarks that month's saving toward the
+   goal (a `BUDGET_LOCK` allocation), inside the same lock transaction.
 3. **Execute** — during the month the couple works through the todo list
    (optimistic checkboxes) and records manual balance corrections with date +
    comment as reality drifts.
 4. **Correct** — unlock fully reverses a lock: balances restored, todo list
-   deleted, recurring-template stamps reverted. Only the most recent budget
-   can be locked; one unlocked budget exists at a time (the working draft).
+   deleted, recurring-template stamps reverted, and goal earmarks made on lock
+   removed. Only the most recent budget can be locked; one unlocked budget
+   exists at a time (the working draft).
 
 ## System architecture
 
@@ -74,7 +77,9 @@ in the item 015 review; focused charts that aid the monthly routine are welcome.
   `UNLOCKED|LOCKED`, lockedAt. Soft delete (unlocked budgets only).
 - **BudgetIncome / BudgetExpense / BudgetSavings** — name, amount,
   bankAccount. Expense additionally: optional `recurringExpenseId` link,
-  `isManual` flag, `deductedAt`.
+  `isManual` flag, `deductedAt`. Savings additionally: optional
+  `savingsGoalId` (item 070c) — links the line to a goal so locking earmarks
+  that month's saving toward it and unlocking reverses it.
 - **RecurringExpense** — template: name, amount, interval
   `MONTHLY|QUARTERLY|BIANNUALLY|YEARLY`, isManual, optional default
   bankAccount; lastUsedBudgetId/Month/Year stamped on lock (due = last used +
@@ -96,9 +101,9 @@ in the item 015 review; focused charts that aid the monthly routine are welcome.
   `MANUAL|BUDGET_LOCK|BALANCE_REALLOCATION|ARCHIVE`. Written on every
   allocation change; preserved across archiving and removal.
 
-Money is `BigDecimal` / `NUMERIC(19,2)` everywhere. Flyway migrations V1–V5
+Money is `BigDecimal` / `NUMERIC(19,2)` everywhere. Flyway migrations V1–V6
 (V4 dropped the deprecated `last_used_date` column; V5 added the savings-goals
-tables).
+tables; V6 added the nullable `budget_savings.savings_goal_id` FK).
 
 ## API surface (summary — details in Swagger)
 
@@ -117,7 +122,9 @@ tables).
 - `/api/budgets` — POST, GET (with totals); `/{id}` GET, DELETE; `/{id}/lock`
   PUT; `/{id}/unlock` PUT; `/{budgetId}/income|expenses|savings` POST and
   `…/{itemId}` PUT, DELETE; `/{budgetId}/todo-list` GET;
-  `/{budgetId}/todo-list/items/{id}` PUT.
+  `/{budgetId}/todo-list/items/{id}` PUT. Savings create/update accept an
+  optional `savingsGoalId` (item 070c; additive, defaults to null) echoed back
+  on savings responses.
 - `/api/recurring-expenses` — POST, GET; `/{id}` GET, PUT, DELETE.
 - There is no `PUT /api/budgets/{id}` — month/year is not editable after
   creation (a possible future item; not yet specced).
@@ -139,7 +146,9 @@ tables).
   and tighter padding at `md+` so more fit on desktop (item 050).
 - `/budgets/:id` — income/expenses/savings sections with add/edit/delete
   modals (UNLOCKED only); summary with balance bar; lock/unlock/delete
-  actions; link to the todo page when locked. On UNLOCKED budgets a
+  actions; link to the todo page when locked. The savings add/edit modal has an
+  optional **Goal** selector (item 070c) and savings rows show the linked goal
+  (`account · goal`). On UNLOCKED budgets a
   "due recurring expenses not added" hint above the expenses section lists
   recurring templates due for the budget month or earlier that aren't linked
   from any expense row, with one-click add (item 010).
@@ -196,13 +205,17 @@ Specs live directly in `product/` (filename `NNN-slug.md`, lowest number =
 highest priority). Item 015 scoped six raw feature ideas into these; priority
 order reflects the maintainer's item 015 review (PR preview image first):
 
-- `070c–070e` **savings goals** (remaining parts: budget-savings ↔ goal linking
-  on lock → manual-balance reallocation → progress/predictions). `070a` (backend
-  foundation) and `070b` (frontend goals pages: list, detail, create/edit/
-  assign/archive) are **done** (2026-06-24) — `070c` is the next gate. `070e`
-  adds progress visualizations (charts are in scope — see the non-goals note
-  above), including surfacing the `GoalAllocationChange` history (already
-  fetchable via `GET /{id}/history`; 070b wired the hook but no UI yet).
+- `070d–070e` **savings goals** (remaining parts: manual-balance reallocation →
+  progress/predictions). `070a` (backend foundation), `070b` (frontend goals
+  pages) and `070c` (budget-savings ↔ goal linking on lock/unlock) are **done** —
+  `070d` is the next gate. `070e` adds progress visualizations (charts are in
+  scope — see the non-goals note above), including surfacing the
+  `GoalAllocationChange` history (already fetchable via `GET /{id}/history`;
+  070b wired the hook but no UI yet).
+
+  **Follow-up noted in 070c:** the budget **wizard** savings step does not yet
+  expose the goal selector (only the budget-detail savings modal does); linking
+  during initial budget creation is a small future item.
 
 ## Recently completed
 
@@ -211,6 +224,7 @@ order reflects the maintainer's item 015 review (PR preview image first):
 
 | Date | Item | Repos |
 |---|---|---|
+| 2026-06-25 | Savings-goals budget linking: savings lines link to goals, earmark on lock / reverse on unlock (item 070c) | backend, frontend |
 | 2026-06-24 | Savings-goals frontend pages: list, detail, create/edit/assign/archive (item 070b) | frontend, backend (bookkeeping) |
 | 2026-06-24 | Savings-goals backend foundation: entities, allocation ledger + history, CRUD, archive (item 070a) | backend |
 | 2026-06-23 | Near-real-time cross-device refresh via React Query polling (item 060) | frontend, backend (bookkeeping) |

--- a/product/done/070c-savings-goals-budget-linking.md
+++ b/product/done/070c-savings-goals-budget-linking.md
@@ -86,3 +86,57 @@ defaults to null.
 - This touches the most safety-critical flow (lock/unlock). Preserve the
   invariant that unlock restores pre-lock state **exactly** — now including goal
   allocations. No destructive migrations.
+
+## Completion notes
+
+**Completed:** 2026-06-25 · **PRs:** balance-backend (branch
+`claude/youthful-hamilton-wbbqb0`) + balance-frontend (branch
+`claude/peaceful-hamilton-wbbqb0`). Merge order: **backend first**.
+
+Backend full suite green (360 tests, +15 new in
+`BudgetSavingsGoalLinkIntegrationTest`). Frontend green: lint, `tsc`, 535
+Vitest tests (+5 new on `SavingsItemModal`), and build.
+
+### What shipped
+- **Backend:** `BudgetSavings` gains a nullable `savingsGoalId` (Flyway
+  `V6__add_savings_goal_id_to_budget_savings.sql` — additive nullable column +
+  FK to `savings_goals` + index). The add/update savings endpoints accept an
+  optional `savingsGoalId` (validated to reference an **active** goal — 404 if
+  missing, 400 if archived); `BudgetSavingsResponse` and the budget-detail
+  savings response carry it back. On **lock** each goal-linked savings line
+  earmarks its amount toward the goal on its account (summed per goal+account,
+  reusing the 070a `applyAllocation` so the invariant + `BUDGET_LOCK`
+  `GoalAllocationChange` ledger row come for free); on **unlock** that exact
+  contribution is reversed.
+- **Frontend:** the budget-detail savings add/edit modal
+  (`SavingsItemModal`) gets an optional **Goal** selector (None / pick an
+  active goal); the savings section sublabel shows the linked goal name
+  (`account · goal`). Omitting a goal sends no `savingsGoalId`, so existing
+  behaviour is unchanged.
+
+### Interpretation decisions
+- **Ordering (the documented invariant rule).** On lock the goal allocation
+  step runs **after** `updateBalancesForBudget`, so the savings money has
+  already credited the account; the new earmark is therefore always backed by
+  the just-added balance and the per-account invariant
+  (`Σ allocations ≤ currentBalance`) holds by construction. The
+  `InsufficientUnallocatedFundsException` check inside `applyAllocation` is kept
+  as a safety net — if it ever fired it would roll back the whole lock (the lock
+  is one `@Transactional`). Unlock reverses in the inverse order
+  (de-allocate, then restore balances).
+- **Reversal is delta-based and tolerant.** Unlock subtracts exactly each
+  linked line's amount from the current allocation, clamped at zero, and skips
+  allocations already gone. So a manual allocation made while the budget was
+  locked survives unlock, and a goal archived while locked is not resurrected.
+- **Archived/deleted goals are skipped on lock** (they no longer accept
+  allocations); the lock still succeeds. Linking is validated against active
+  goals at add/update time.
+- **Multiple savings lines to the same goal+account are aggregated** into one
+  allocation change per lock/unlock (one ledger row each), not one per line.
+
+### Deferred (not blocking the acceptance criteria)
+- The **budget wizard** savings step does not yet expose the goal selector —
+  the create-budget flow would need the wizard state + per-line plumbing
+  extended. Goals can be linked by editing a savings line on the budget-detail
+  page after the budget is created. The hard acceptance criterion (the
+  budget-detail savings modal) is fully met. Worth a small follow-up item.

--- a/product/done/070c-savings-goals-budget-linking.md
+++ b/product/done/070c-savings-goals-budget-linking.md
@@ -134,9 +134,17 @@ Vitest tests (+5 new on `SavingsItemModal`), and build.
 - **Multiple savings lines to the same goal+account are aggregated** into one
   allocation change per lock/unlock (one ledger row each), not one per line.
 
-### Deferred (not blocking the acceptance criteria)
-- The **budget wizard** savings step does not yet expose the goal selector —
-  the create-budget flow would need the wizard state + per-line plumbing
-  extended. Goals can be linked by editing a savings line on the budget-detail
-  page after the budget is created. The hard acceptance criterion (the
-  budget-detail savings modal) is fully met. Worth a small follow-up item.
+### Follow-up — wizard selector + faster refetch (added after maintainer review)
+On review of the frontend PR the maintainer asked for the wizard selector and
+quicker goal refresh, so both were folded into the 070c frontend PR:
+- The **budget wizard** savings step now exposes the optional **Goal** selector
+  too (desktop inline table + the mobile edit sheet), with a shared `GoalSelect`
+  component reused by the budget-detail modal and both wizard surfaces.
+  Copy-from-last-budget preserves the link; the review step and mobile card
+  surface the linked goal. So a saving can be earmarked toward a goal during
+  initial budget creation, not only afterwards.
+- **Faster refetch:** locking/unlocking a budget now invalidates the goals
+  queries directly (lock earmarks goal-linked savings), and the React Query
+  default `staleTime` was lowered to `0` so navigation/mount and window focus
+  refetch everywhere — cheap on a two-user LAN, and the goals pages reflect a
+  lock immediately instead of waiting for the 30s poll.

--- a/src/main/java/org/example/axelnyman/main/domain/dtos/BudgetDtos.java
+++ b/src/main/java/org/example/axelnyman/main/domain/dtos/BudgetDtos.java
@@ -142,7 +142,9 @@ public class BudgetDtos {
             BigDecimal amount,
 
             @NotNull(message = "Bank account ID is required")
-            UUID bankAccountId
+            UUID bankAccountId,
+
+            UUID savingsGoalId
     ) {}
 
     public record BudgetSavingsResponse(
@@ -151,6 +153,7 @@ public class BudgetDtos {
             String name,
             BigDecimal amount,
             BankAccountSummary bankAccount,
+            UUID savingsGoalId,
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {}
@@ -164,7 +167,9 @@ public class BudgetDtos {
             BigDecimal amount,
 
             @NotNull(message = "Bank account ID is required")
-            UUID bankAccountId
+            UUID bankAccountId,
+
+            UUID savingsGoalId
     ) {}
 
     // ============================================
@@ -197,7 +202,8 @@ public class BudgetDtos {
             UUID id,
             String name,
             BigDecimal amount,
-            BankAccountSummarySimple bankAccount
+            BankAccountSummarySimple bankAccount,
+            UUID savingsGoalId
     ) {}
 
     public record BudgetDetailResponse(

--- a/src/main/java/org/example/axelnyman/main/domain/extensions/BudgetExtensions.java
+++ b/src/main/java/org/example/axelnyman/main/domain/extensions/BudgetExtensions.java
@@ -81,7 +81,8 @@ public final class BudgetExtensions {
                 savings.getId(),
                 savings.getName(),
                 savings.getAmount(),
-                toBankAccountSummarySimple(savings.getBankAccount())
+                toBankAccountSummarySimple(savings.getBankAccount()),
+                savings.getSavingsGoalId()
         );
     }
 

--- a/src/main/java/org/example/axelnyman/main/domain/extensions/BudgetSavingsExtensions.java
+++ b/src/main/java/org/example/axelnyman/main/domain/extensions/BudgetSavingsExtensions.java
@@ -25,17 +25,20 @@ public final class BudgetSavingsExtensions {
                 savings.getName(),
                 savings.getAmount(),
                 bankAccountSummary,
+                savings.getSavingsGoalId(),
                 savings.getCreatedAt(),
                 savings.getUpdatedAt()
         );
     }
 
     public static BudgetSavings toEntity(CreateBudgetSavingsRequest request, UUID budgetId) {
-        return new BudgetSavings(
+        BudgetSavings savings = new BudgetSavings(
                 budgetId,
                 request.bankAccountId(),
                 request.name(),
                 request.amount()
         );
+        savings.setSavingsGoalId(request.savingsGoalId());
+        return savings;
     }
 }

--- a/src/main/java/org/example/axelnyman/main/domain/model/BudgetSavings.java
+++ b/src/main/java/org/example/axelnyman/main/domain/model/BudgetSavings.java
@@ -30,6 +30,9 @@ public final class BudgetSavings {
     @Column(nullable = false, precision = 19, scale = 2)
     private BigDecimal amount;
 
+    @Column
+    private UUID savingsGoalId;
+
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -97,6 +100,14 @@ public final class BudgetSavings {
 
     public void setAmount(BigDecimal amount) {
         this.amount = amount;
+    }
+
+    public UUID getSavingsGoalId() {
+        return savingsGoalId;
+    }
+
+    public void setSavingsGoalId(UUID savingsGoalId) {
+        this.savingsGoalId = savingsGoalId;
     }
 
     public LocalDateTime getCreatedAt() {

--- a/src/main/java/org/example/axelnyman/main/domain/services/DomainService.java
+++ b/src/main/java/org/example/axelnyman/main/domain/services/DomainService.java
@@ -709,6 +709,9 @@ public class DomainService implements IDomainService {
             throw new BankAccountNotFoundException("Bank account not found with id: " + request.bankAccountId());
         }
 
+        // Validate the optional savings-goal link (must reference an active goal)
+        requireActiveGoalIfPresent(request.savingsGoalId());
+
         // Create and save budget savings
         BudgetSavings budgetSavings = BudgetSavingsExtensions.toEntity(request, budgetId);
         BudgetSavings savedSavings = dataService.saveBudgetSavings(budgetSavings);
@@ -746,10 +749,14 @@ public class DomainService implements IDomainService {
             throw new BankAccountNotFoundException("Bank account not found with id: " + request.bankAccountId());
         }
 
-        // Update fields
+        // Validate the optional savings-goal link (must reference an active goal)
+        requireActiveGoalIfPresent(request.savingsGoalId());
+
+        // Update fields (a null savingsGoalId unlinks the goal)
         savings.setName(request.name());
         savings.setAmount(request.amount());
         savings.setBankAccountId(request.bankAccountId());
+        savings.setSavingsGoalId(request.savingsGoalId());
 
         // Save (updatedAt will be auto-updated by JPA auditing)
         BudgetSavings updatedSavings = dataService.saveBudgetSavings(savings);
@@ -843,6 +850,11 @@ public class DomainService implements IDomainService {
 
         // Update account balances based on savings (Story 26)
         updateBalancesForBudget(budgetId, savedBudget);
+
+        // Earmark goal-linked savings toward their goals (item 070c). Done after
+        // the balance update above so the savings money already credits each
+        // account, keeping the unallocated invariant satisfied.
+        allocateSavingsToGoalsOnLock(budgetId);
 
         // Update recurring expenses for this budget
         updateRecurringExpensesForBudget(budgetId, lockedAt, savedBudget.getMonth(), savedBudget.getYear());
@@ -940,6 +952,10 @@ public class DomainService implements IDomainService {
         if (!budget.getId().equals(mostRecentBudget.getId())) {
             throw new NotMostRecentBudgetException("Only the most recent budget can be unlocked");
         }
+
+        // Reverse goal allocations made on lock (item 070c) before restoring
+        // balances — the inverse order of lock (allocate after balance update).
+        reverseSavingsGoalAllocationsOnUnlock(budgetId);
 
         // Reverse balance changes
         reverseBalanceChanges(budgetId);
@@ -1293,6 +1309,65 @@ public class DomainService implements IDomainService {
 
         dataService.saveGoalAllocationChange(new GoalAllocationChange(
                 goalId, account.getId(), changeAmount, newAmount, source));
+    }
+
+    /**
+     * On budget lock, earmark each goal-linked savings line toward its goal:
+     * increase the goal's allocation on the savings item's account by the line's
+     * amount (summed per goal+account), writing a {@code BUDGET_LOCK} ledger row.
+     * Savings whose goal was archived or deleted since linking are skipped — those
+     * goals no longer accept allocations. Runs inside the lock transaction; an
+     * over-allocation would surface {@link InsufficientUnallocatedFundsException}
+     * and roll back the whole lock.
+     */
+    private void allocateSavingsToGoalsOnLock(UUID budgetId) {
+        savingsAmountByGoalAndAccount(budgetId).forEach((key, amount) -> {
+            SavingsGoal goal = dataService.getSavingsGoalById(key.goalId()).orElse(null);
+            if (goal == null || goal.getStatus() != GoalStatus.ACTIVE) {
+                return;
+            }
+            BankAccount account = requireActiveAccount(key.accountId());
+            BigDecimal current = dataService.getGoalAllocation(key.goalId(), key.accountId())
+                    .map(GoalAllocation::getAmount).orElse(BigDecimal.ZERO);
+            applyAllocation(key.goalId(), account, current.add(amount), GoalAllocationChangeSource.BUDGET_LOCK);
+        });
+    }
+
+    /**
+     * On unlock, undo exactly the allocation each goal-linked savings line added
+     * on lock: reduce the goal's allocation on the account by the line's amount
+     * (summed per goal+account), writing the reversing ledger row. Tolerant of
+     * concurrent changes while the budget was locked — clamps at zero and skips
+     * allocations already removed (e.g. by archiving the goal).
+     */
+    private void reverseSavingsGoalAllocationsOnUnlock(UUID budgetId) {
+        savingsAmountByGoalAndAccount(budgetId).forEach((key, amount) -> {
+            Optional<GoalAllocation> existing = dataService.getGoalAllocation(key.goalId(), key.accountId());
+            BigDecimal current = existing.map(GoalAllocation::getAmount).orElse(BigDecimal.ZERO);
+            if (current.compareTo(BigDecimal.ZERO) == 0) {
+                return;
+            }
+            BankAccount account = requireActiveAccount(key.accountId());
+            BigDecimal reversed = current.subtract(amount).max(BigDecimal.ZERO);
+            applyAllocation(key.goalId(), account, reversed, GoalAllocationChangeSource.BUDGET_LOCK);
+        });
+    }
+
+    private Map<GoalAccountKey, BigDecimal> savingsAmountByGoalAndAccount(UUID budgetId) {
+        return dataService.getBudgetSavingsByBudgetId(budgetId).stream()
+                .filter(savings -> savings.getSavingsGoalId() != null)
+                .collect(Collectors.groupingBy(
+                        savings -> new GoalAccountKey(savings.getSavingsGoalId(), savings.getBankAccountId()),
+                        Collectors.reducing(BigDecimal.ZERO, BudgetSavings::getAmount, BigDecimal::add)));
+    }
+
+    private record GoalAccountKey(UUID goalId, UUID accountId) {
+    }
+
+    private void requireActiveGoalIfPresent(UUID goalId) {
+        if (goalId != null) {
+            requireActiveGoal(goalId);
+        }
     }
 
     private SavingsGoalResponse buildGoalResponse(SavingsGoal goal) {

--- a/src/main/resources/db/migration/V6__add_savings_goal_id_to_budget_savings.sql
+++ b/src/main/resources/db/migration/V6__add_savings_goal_id_to_budget_savings.sql
@@ -1,0 +1,18 @@
+-- V6__add_savings_goal_id_to_budget_savings.sql
+-- Budget-savings ↔ goal linking (item 070c): a budget savings line may
+-- optionally reference one savings goal. On budget lock that month's saving is
+-- earmarked toward the goal; on unlock it is reversed.
+-- Additive only: the column is nullable and existing rows default to NULL, so
+-- the currently deployed backend starts unchanged against this schema.
+--
+-- Rollback (manual):
+--   ALTER TABLE budget_savings DROP CONSTRAINT fk_budget_savings_savings_goal;
+--   DROP INDEX idx_budget_savings_savings_goal_id;
+--   ALTER TABLE budget_savings DROP COLUMN savings_goal_id;
+
+ALTER TABLE budget_savings ADD COLUMN savings_goal_id UUID;
+
+ALTER TABLE budget_savings ADD CONSTRAINT fk_budget_savings_savings_goal
+    FOREIGN KEY (savings_goal_id) REFERENCES savings_goals(id);
+
+CREATE INDEX idx_budget_savings_savings_goal_id ON budget_savings(savings_goal_id);

--- a/src/test/java/org/example/axelnyman/main/integration/BudgetSavingsGoalLinkIntegrationTest.java
+++ b/src/test/java/org/example/axelnyman/main/integration/BudgetSavingsGoalLinkIntegrationTest.java
@@ -1,0 +1,498 @@
+package org.example.axelnyman.main.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.axelnyman.main.domain.dtos.BankAccountDtos.CreateBankAccountRequest;
+import org.example.axelnyman.main.domain.dtos.SavingsGoalDtos.*;
+import org.example.axelnyman.main.infrastructure.data.context.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Integration tests for item 070c: linking budget savings lines to savings
+ * goals and allocating/reversing those goals on budget lock/unlock.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Testcontainers
+public class BudgetSavingsGoalLinkIntegrationTest {
+
+    @Container
+    @SuppressWarnings("resource")
+    static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgreSQLContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", postgreSQLContainer::getUsername);
+        registry.add("spring.datasource.password", postgreSQLContainer::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    }
+
+    @Autowired
+    private WebApplicationContext context;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private BudgetRepository budgetRepository;
+    @Autowired
+    private BudgetIncomeRepository budgetIncomeRepository;
+    @Autowired
+    private BudgetExpenseRepository budgetExpenseRepository;
+    @Autowired
+    private BudgetSavingsRepository budgetSavingsRepository;
+    @Autowired
+    private TodoItemRepository todoItemRepository;
+    @Autowired
+    private TodoListRepository todoListRepository;
+    @Autowired
+    private GoalAllocationChangeRepository goalAllocationChangeRepository;
+    @Autowired
+    private GoalAllocationRepository goalAllocationRepository;
+    @Autowired
+    private SavingsGoalRepository savingsGoalRepository;
+    @Autowired
+    private BalanceHistoryRepository balanceHistoryRepository;
+    @Autowired
+    private BankAccountRepository bankAccountRepository;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+
+        todoItemRepository.deleteAll();
+        todoListRepository.deleteAll();
+        budgetIncomeRepository.deleteAll();
+        budgetExpenseRepository.deleteAll();
+        budgetSavingsRepository.deleteAll();
+        budgetRepository.deleteAll();
+        goalAllocationChangeRepository.deleteAll();
+        goalAllocationRepository.deleteAll();
+        savingsGoalRepository.deleteAll();
+        balanceHistoryRepository.deleteAll();
+        bankAccountRepository.deleteAll();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (postgreSQLContainer != null && postgreSQLContainer.isRunning()) {
+            postgreSQLContainer.stop();
+        }
+    }
+
+    // ==================== Linking on add / update ====================
+
+    @Test
+    void shouldPersistGoalLinkWhenAddingSavingsWithGoal() throws Exception {
+        UUID accountId = createAccount("Savings", "1000.00");
+        UUID goalId = createGoal("Vacation", null);
+        UUID budgetId = createBudget(6, 2024);
+
+        UUID savingsId = addSavings(budgetId, accountId, "Trip", "500.00", goalId);
+
+        mockMvc.perform(get("/api/budgets/" + budgetId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.savings[0].id", is(savingsId.toString())))
+                .andExpect(jsonPath("$.savings[0].savingsGoalId", is(goalId.toString())));
+    }
+
+    @Test
+    void shouldKeepNullGoalLinkWhenAddingSavingsWithoutGoal() throws Exception {
+        UUID accountId = createAccount("Savings", "1000.00");
+        UUID budgetId = createBudget(6, 2024);
+
+        addSavings(budgetId, accountId, "Trip", "500.00", null);
+
+        mockMvc.perform(get("/api/budgets/" + budgetId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.savings[0].savingsGoalId").doesNotExist());
+    }
+
+    @Test
+    void shouldRejectLinkingSavingsToNonexistentGoal() throws Exception {
+        UUID accountId = createAccount("Savings", "1000.00");
+        UUID budgetId = createBudget(6, 2024);
+
+        mockMvc.perform(post("/api/budgets/" + budgetId + "/savings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(savingsBody(accountId, "Trip", "500.00", UUID.randomUUID())))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldRejectLinkingSavingsToArchivedGoal() throws Exception {
+        UUID accountId = createAccount("Savings", "1000.00");
+        UUID goalId = createGoal("Vacation", null);
+        archiveGoal(goalId, false);
+        UUID budgetId = createBudget(6, 2024);
+
+        mockMvc.perform(post("/api/budgets/" + budgetId + "/savings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(savingsBody(accountId, "Trip", "500.00", goalId)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldUnlinkGoalWhenUpdatingSavingsWithoutGoal() throws Exception {
+        UUID accountId = createAccount("Savings", "1000.00");
+        UUID goalId = createGoal("Vacation", null);
+        UUID budgetId = createBudget(6, 2024);
+        UUID savingsId = addSavings(budgetId, accountId, "Trip", "500.00", goalId);
+
+        mockMvc.perform(put("/api/budgets/" + budgetId + "/savings/" + savingsId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(savingsBody(accountId, "Trip", "500.00", null)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/budgets/" + budgetId))
+                .andExpect(jsonPath("$.savings[0].savingsGoalId").doesNotExist());
+    }
+
+    // ==================== Allocation on lock ====================
+
+    @Test
+    void shouldAllocateToGoalOnLockForLinkedSavings() throws Exception {
+        UUID accountId = createAccount("Savings", "1000.00");
+        UUID goalId = createGoal("Vacation", "2000.00");
+        UUID budgetId = createBudget(6, 2024);
+        addIncome(budgetId, accountId, "Salary", "500.00");
+        addSavings(budgetId, accountId, "Trip", "500.00", goalId);
+
+        lock(budgetId);
+
+        // Goal now holds the saved amount on the account.
+        mockMvc.perform(get("/api/savings-goals/" + goalId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalAllocated", is(500.00)))
+                .andExpect(jsonPath("$.allocations[0].bankAccountId", is(accountId.toString())))
+                .andExpect(jsonPath("$.allocations[0].amount", is(500.00)));
+
+        // A BUDGET_LOCK ledger row records the change.
+        mockMvc.perform(get("/api/savings-goals/" + goalId + "/history"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.changes[0].source", is("BUDGET_LOCK")))
+                .andExpect(jsonPath("$.changes[0].changeAmount", is(500.00)))
+                .andExpect(jsonPath("$.changes[0].resultingAmount", is(500.00)));
+
+        // Balance was credited by savings (1500); 500 is earmarked, 1000 free.
+        assertAccountAllocations(accountId, "500.00", "1000.00");
+    }
+
+    @Test
+    void shouldAddToExistingAllocationOnLock() throws Exception {
+        UUID accountId = createAccount("Savings", "1000.00");
+        // Goal already earmarks 200 of the account's balance.
+        UUID goalId = createGoalWithSeed("Vacation", accountId, "200.00");
+        UUID budgetId = createBudget(6, 2024);
+        addIncome(budgetId, accountId, "Salary", "300.00");
+        addSavings(budgetId, accountId, "Trip", "300.00", goalId);
+
+        lock(budgetId);
+
+        mockMvc.perform(get("/api/savings-goals/" + goalId))
+                .andExpect(jsonPath("$.totalAllocated", is(500.00)))
+                .andExpect(jsonPath("$.allocations[0].amount", is(500.00)));
+    }
+
+    @Test
+    void shouldAggregateMultipleSavingsLinesToSameGoalAndAccountOnLock() throws Exception {
+        UUID accountId = createAccount("Savings", "1000.00");
+        UUID goalId = createGoal("Vacation", null);
+        UUID budgetId = createBudget(6, 2024);
+        addIncome(budgetId, accountId, "Salary", "500.00");
+        addSavings(budgetId, accountId, "Flights", "300.00", goalId);
+        addSavings(budgetId, accountId, "Hotel", "200.00", goalId);
+
+        lock(budgetId);
+
+        mockMvc.perform(get("/api/savings-goals/" + goalId))
+                .andExpect(jsonPath("$.totalAllocated", is(500.00)))
+                .andExpect(jsonPath("$.allocations", hasSize(1)))
+                .andExpect(jsonPath("$.allocations[0].amount", is(500.00)));
+    }
+
+    @Test
+    void shouldNotAllocateOnLockWhenSavingsHasNoGoal() throws Exception {
+        UUID accountId = createAccount("Savings", "1000.00");
+        UUID goalId = createGoal("Vacation", null);
+        UUID budgetId = createBudget(6, 2024);
+        addIncome(budgetId, accountId, "Salary", "500.00");
+        addSavings(budgetId, accountId, "Trip", "500.00", null);
+
+        lock(budgetId);
+
+        // Goal untouched; account balance still credited as before (no earmark).
+        mockMvc.perform(get("/api/savings-goals/" + goalId))
+                .andExpect(jsonPath("$.totalAllocated", is(0)))
+                .andExpect(jsonPath("$.allocations", hasSize(0)));
+        assertAccountAllocations(accountId, "0.00", "1500.00");
+    }
+
+    @Test
+    void shouldSkipArchivedGoalAllocationOnLock() throws Exception {
+        UUID accountId = createAccount("Savings", "1000.00");
+        UUID goalId = createGoal("Vacation", null);
+        UUID budgetId = createBudget(6, 2024);
+        addIncome(budgetId, accountId, "Salary", "500.00");
+        addSavings(budgetId, accountId, "Trip", "500.00", goalId);
+
+        // Goal archived after linking but before lock — lock must still succeed
+        // and create no allocation for the archived goal.
+        archiveGoal(goalId, false);
+
+        lock(budgetId);
+
+        mockMvc.perform(get("/api/budgets/" + budgetId))
+                .andExpect(jsonPath("$.status", is("LOCKED")));
+        assertAccountAllocations(accountId, "0.00", "1500.00");
+    }
+
+    @Test
+    void shouldKeepUnallocatedInvariantWhenAccountFullyAllocatedBeforeLock() throws Exception {
+        UUID accountId = createAccount("Savings", "1000.00");
+        // Account starts fully earmarked by another goal.
+        createGoalWithSeed("Buffer", accountId, "1000.00");
+        UUID goalId = createGoal("Vacation", null);
+        UUID budgetId = createBudget(6, 2024);
+        addIncome(budgetId, accountId, "Salary", "400.00");
+        addSavings(budgetId, accountId, "Trip", "400.00", goalId);
+
+        // The saving credits the account by 400, backing the new 400 earmark, so
+        // the lock succeeds and leaves no unallocated money negative.
+        lock(budgetId);
+
+        mockMvc.perform(get("/api/savings-goals/" + goalId))
+                .andExpect(jsonPath("$.totalAllocated", is(400.00)));
+        assertAccountAllocations(accountId, "1400.00", "0.00");
+    }
+
+    // ==================== Reversal on unlock ====================
+
+    @Test
+    void shouldReverseGoalAllocationOnUnlock() throws Exception {
+        UUID accountId = createAccount("Savings", "1000.00");
+        UUID goalId = createGoal("Vacation", null);
+        UUID budgetId = createBudget(6, 2024);
+        addIncome(budgetId, accountId, "Salary", "500.00");
+        addSavings(budgetId, accountId, "Trip", "500.00", goalId);
+        lock(budgetId);
+
+        unlock(budgetId);
+
+        // Allocation fully removed; account restored to pre-lock state.
+        mockMvc.perform(get("/api/savings-goals/" + goalId))
+                .andExpect(jsonPath("$.totalAllocated", is(0)))
+                .andExpect(jsonPath("$.allocations", hasSize(0)));
+        assertAccountAllocations(accountId, "0.00", "1000.00");
+
+        // History keeps both the lock and the reversing rows (newest first).
+        mockMvc.perform(get("/api/savings-goals/" + goalId + "/history"))
+                .andExpect(jsonPath("$.changes", hasSize(2)))
+                .andExpect(jsonPath("$.changes[0].source", is("BUDGET_LOCK")))
+                .andExpect(jsonPath("$.changes[0].changeAmount", is(-500.00)))
+                .andExpect(jsonPath("$.changes[0].resultingAmount", is(0.00)));
+    }
+
+    @Test
+    void shouldRestoreOnlySeededAllocationWhenUnlockingGoalWithPriorAllocation() throws Exception {
+        UUID accountId = createAccount("Savings", "1000.00");
+        UUID goalId = createGoalWithSeed("Vacation", accountId, "200.00");
+        UUID budgetId = createBudget(6, 2024);
+        addIncome(budgetId, accountId, "Salary", "300.00");
+        addSavings(budgetId, accountId, "Trip", "300.00", goalId);
+        lock(budgetId);
+
+        unlock(budgetId);
+
+        // Lock added 300 on top of the seeded 200; unlock removes exactly 300.
+        mockMvc.perform(get("/api/savings-goals/" + goalId))
+                .andExpect(jsonPath("$.totalAllocated", is(200.00)))
+                .andExpect(jsonPath("$.allocations[0].amount", is(200.00)));
+        assertAccountAllocations(accountId, "200.00", "800.00");
+    }
+
+    @Test
+    void shouldPreserveManualAllocationMadeWhileLocked() throws Exception {
+        UUID accountId = createAccount("Savings", "1000.00");
+        UUID goalId = createGoal("Vacation", null);
+        UUID budgetId = createBudget(6, 2024);
+        addIncome(budgetId, accountId, "Salary", "300.00");
+        addSavings(budgetId, accountId, "Trip", "300.00", goalId);
+        lock(budgetId);
+
+        // While locked the user manually bumps the same earmark by 100 (300 -> 400).
+        allocate(goalId, accountId, "400.00");
+
+        unlock(budgetId);
+
+        // Only the lock's 300 is reversed; the manual +100 survives.
+        mockMvc.perform(get("/api/savings-goals/" + goalId))
+                .andExpect(jsonPath("$.totalAllocated", is(100.00)))
+                .andExpect(jsonPath("$.allocations[0].amount", is(100.00)));
+    }
+
+    @Test
+    void shouldNotRecreateAllocationOnUnlockWhenGoalArchivedWhileLocked() throws Exception {
+        UUID accountId = createAccount("Savings", "1000.00");
+        UUID goalId = createGoal("Vacation", null);
+        UUID budgetId = createBudget(6, 2024);
+        addIncome(budgetId, accountId, "Salary", "500.00");
+        addSavings(budgetId, accountId, "Trip", "500.00", goalId);
+        lock(budgetId);
+
+        // Archiving (releaseToBalance=false) frees the earmark while locked.
+        archiveGoal(goalId, false);
+
+        // Unlock must not resurrect the allocation for the archived goal.
+        unlock(budgetId);
+
+        mockMvc.perform(get("/api/savings-goals/" + goalId))
+                .andExpect(jsonPath("$.totalAllocated", is(0)))
+                .andExpect(jsonPath("$.allocations", hasSize(0)));
+    }
+
+    // ---------- helpers ----------
+
+    private UUID createAccount(String name, String balance) throws Exception {
+        String response = mockMvc.perform(post("/api/bank-accounts")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                        new CreateBankAccountRequest(name, null, new BigDecimal(balance)))))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return UUID.fromString(objectMapper.readTree(response).get("id").asText());
+    }
+
+    private UUID createGoal(String name, String targetAmount) throws Exception {
+        return createGoalInternal(new CreateSavingsGoalRequest(
+                name, targetAmount == null ? null : new BigDecimal(targetAmount), null, null));
+    }
+
+    private UUID createGoalWithSeed(String name, UUID accountId, String amount) throws Exception {
+        return createGoalInternal(new CreateSavingsGoalRequest(name, null, null,
+                List.of(new SeedAllocationRequest(accountId, new BigDecimal(amount)))));
+    }
+
+    private UUID createGoalInternal(CreateSavingsGoalRequest request) throws Exception {
+        String response = mockMvc.perform(post("/api/savings-goals")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return UUID.fromString(objectMapper.readTree(response).get("id").asText());
+    }
+
+    private void allocate(UUID goalId, UUID accountId, String amount) throws Exception {
+        mockMvc.perform(post("/api/savings-goals/" + goalId + "/allocations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                        new AllocateRequest(accountId, new BigDecimal(amount)))))
+                .andExpect(status().isOk());
+    }
+
+    private void archiveGoal(UUID goalId, boolean releaseToBalance) throws Exception {
+        mockMvc.perform(post("/api/savings-goals/" + goalId + "/archive")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new ArchiveRequest(releaseToBalance))))
+                .andExpect(status().isOk());
+    }
+
+    private UUID createBudget(int month, int year) throws Exception {
+        Map<String, Object> body = new HashMap<>();
+        body.put("month", month);
+        body.put("year", year);
+        String response = mockMvc.perform(post("/api/budgets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return UUID.fromString(objectMapper.readTree(response).get("id").asText());
+    }
+
+    private void addIncome(UUID budgetId, UUID accountId, String name, String amount) throws Exception {
+        Map<String, Object> body = new HashMap<>();
+        body.put("bankAccountId", accountId.toString());
+        body.put("name", name);
+        body.put("amount", new BigDecimal(amount));
+        mockMvc.perform(post("/api/budgets/" + budgetId + "/income")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isCreated());
+    }
+
+    private UUID addSavings(UUID budgetId, UUID accountId, String name, String amount, UUID goalId)
+            throws Exception {
+        String response = mockMvc.perform(post("/api/budgets/" + budgetId + "/savings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(savingsBody(accountId, name, amount, goalId)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return UUID.fromString(objectMapper.readTree(response).get("id").asText());
+    }
+
+    private String savingsBody(UUID accountId, String name, String amount, UUID goalId)
+            throws Exception {
+        Map<String, Object> body = new HashMap<>();
+        body.put("bankAccountId", accountId.toString());
+        body.put("name", name);
+        body.put("amount", new BigDecimal(amount));
+        if (goalId != null) {
+            body.put("savingsGoalId", goalId.toString());
+        }
+        return objectMapper.writeValueAsString(body);
+    }
+
+    private void lock(UUID budgetId) throws Exception {
+        mockMvc.perform(put("/api/budgets/" + budgetId + "/lock"))
+                .andExpect(status().isOk());
+    }
+
+    private void unlock(UUID budgetId) throws Exception {
+        mockMvc.perform(put("/api/budgets/" + budgetId + "/unlock"))
+                .andExpect(status().isOk());
+    }
+
+    private void assertAccountAllocations(UUID accountId, String allocated, String unallocated)
+            throws Exception {
+        String response = mockMvc.perform(get("/api/bank-accounts"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        var accounts = objectMapper.readTree(response).get("accounts");
+        var node = java.util.stream.StreamSupport.stream(accounts.spliterator(), false)
+                .filter(a -> a.get("id").asText().equals(accountId.toString()))
+                .findFirst().orElseThrow();
+        org.assertj.core.api.Assertions.assertThat(new BigDecimal(node.get("allocatedAmount").asText()))
+                .isEqualByComparingTo(allocated);
+        org.assertj.core.api.Assertions.assertThat(new BigDecimal(node.get("unallocatedAmount").asText()))
+                .isEqualByComparingTo(unallocated);
+    }
+}


### PR DESCRIPTION
## What

Part 3 of 5 of the savings-goals feature. Lets a budget **savings** line optionally reference one savings goal, and wires that into the lock/unlock flow:

- `BudgetSavings` gains a nullable `savingsGoalId` (Flyway **V6** — additive nullable column + FK to `savings_goals` + index; the currently deployed backend still starts against the new schema).
- The add/update savings endpoints accept an optional `savingsGoalId`; omitting it preserves today's behaviour (the deployed frontend keeps working). It's validated to reference an **active** goal — `404` if missing, `400` if archived.
- `BudgetSavingsResponse` and the budget-detail savings response echo `savingsGoalId` back.
- On **lock**, each goal-linked savings line earmarks its amount toward the goal on the line's account (summed per goal+account), reusing the 070a `applyAllocation` so the invariant check and a `BUDGET_LOCK` `GoalAllocationChange` ledger row come for free.
- On **unlock**, exactly that contribution is reversed.

Both run inside the existing lock/unlock `@Transactional`.

## Why

The monthly routine already plans savings per account. Linking a savings line to a goal means locking the budget automatically earmarks that month's saving toward the goal (and unlocking undoes it), so goals stay accurate without separate manual bookkeeping.

## Interpretation decisions

- **Ordering (the documented invariant rule).** The goal-allocation step runs **after** `updateBalancesForBudget` on lock, so the savings money has already credited the account; the new earmark is therefore always backed by the just-added balance and the per-account invariant (`Σ allocations ≤ currentBalance`) holds by construction. The `InsufficientUnallocatedFundsException` check inside `applyAllocation` is kept as a safety net — if it ever fired it would roll back the whole lock. Unlock reverses in the inverse order (de-allocate, then restore balances).
- **Reversal is delta-based and tolerant.** Unlock subtracts exactly each linked line's amount from the current allocation, clamped at zero, and skips allocations already gone — so a manual allocation made while the budget was locked survives unlock, and a goal archived while locked is not resurrected.
- **Archived/deleted goals are skipped on lock** (they no longer accept allocations); the lock still succeeds.
- **Multiple savings lines to the same goal+account are aggregated** into one allocation change per lock/unlock.

## Test evidence

New `BudgetSavingsGoalLinkIntegrationTest` (15 cases): linking on add/update, rejection of nonexistent (404) / archived (400) goals, unlinking on update, allocate-on-lock (single, additive over a prior allocation, aggregated multi-line), no-goal lock unchanged, archived-goal skip, invariant held when account fully allocated, reverse-on-unlock (full, partial over a seeded allocation), manual allocation preserved across unlock, and no resurrection of an archived goal.

```
./mvnw test  →  Tests run: 360, Failures: 0, Errors: 0  BUILD SUCCESS
```

Environment note (same as 070a): Docker Hub/ECR blobs are blocked by the egress policy here, so `postgres:15-alpine` was pulled via `mirror.gcr.io` and tagged locally, and the suite ran with `TESTCONTAINERS_RYUK_DISABLED=true` (ryuk image likewise blocked). JDK 21 building a Java 17 target, as documented.

## Assumptions / limitations

- The budget **wizard** savings step does not yet expose the goal selector — only the budget-detail savings modal does. Goals can be linked by editing a savings line after the budget is created. Noted as a small follow-up in STATE.md.

## Bookkeeping

Spec moved to `product/done/070c-…` with completion notes; `STATE.md` updated (domain model, lock/unlock flow, API surface, frontend pages, migrations V1–V6, open backlog, recently-completed).

Backlog item: 070c-savings-goals-budget-linking

---

Full-stack item — sibling frontend PR: **axel-nyman/balance-frontend** branch `claude/peaceful-hamilton-wbbqb0` (adds the savings-modal goal selector). **Merge this backend PR first**; the frontend change is additive on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLfrKB5Tu8uhT294AF2Hnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLfrKB5Tu8uhT294AF2Hnm)_