### PR TITLE
feat: reconcile savings-goal allocations on manual balance updates (item 070d)

### DIFF
--- a/product/STATE.md
+++ b/product/STATE.md
@@ -6,7 +6,7 @@
 > `CHANGELOG.md` (generated — never hand-edit), and `.claude/thoughts/` in
 > both repos for engineering research and plans.
 
-**Last updated:** 2026-06-25 (item 070c — budget savings ↔ goal linking on lock)
+**Last updated:** 2026-06-25 (item 070d — manual balance changes reconcile goal allocations)
 
 ## What Balance is
 
@@ -42,7 +42,11 @@ in the item 015 review; focused charts that aid the monthly routine are welcome.
    goal (a `BUDGET_LOCK` allocation), inside the same lock transaction.
 3. **Execute** — during the month the couple works through the todo list
    (optimistic checkboxes) and records manual balance corrections with date +
-   comment as reality drifts.
+   comment as reality drifts. A manual balance change on a goal-backed account
+   keeps earmarks truthful (item 070d): a decrease that over-allocates auto-reduces
+   a single backing goal (or prompts for a split across several), and an increase
+   optionally earmarks straight onto a goal — all inside the balance-update
+   transaction, writing `BALANCE_REALLOCATION` history.
 4. **Correct** — unlock fully reverses a lock: balances restored, todo list
    deleted, recurring-template stamps reverted, and goal earmarks made on lock
    removed. Only the most recent budget can be locked; one unlocked budget
@@ -110,7 +114,11 @@ tables; V6 added the nullable `budget_savings.savings_goal_id` FK).
 - `/api/bank-accounts` — POST, GET (includes totalBalance); `/{id}` PUT,
   DELETE; `/{id}/balance` POST (manual update); `/{id}/balance-history` GET
   (paginated). `BankAccountResponse` now also carries `allocatedAmount` /
-  `unallocatedAmount` (additive, item 070a).
+  `unallocatedAmount` (additive, item 070a). The balance POST accepts an optional
+  signed `reallocation` list to reconcile goal earmarks (item 070d): a single-goal
+  deficit auto-reduces; a multi-goal deficit without a split returns `409` with the
+  conflict detail; an increase can earmark money straight onto goals. The response
+  carries additive `allocationAdjustments`. Legacy request shape still works.
 - `/api/savings-goals` (item 070a) — POST (optional seed allocations from
   accounts' unallocated money), GET (active goals with per-goal summary:
   totalAllocated, progress, backing accounts; archived excluded); `/{id}` GET
@@ -133,7 +141,10 @@ tables; V6 added the nullable `budget_savings.savings_goal_id` FK).
 
 - `/accounts` — totals header; account list; create/edit/delete via modals;
   update-balance modal (date + comment); balance-history drawer with infinite
-  scroll.
+  scroll. On a goal-backed account the update-balance modal reconciles earmarks
+  (item 070d): an increase offers a pre-checked-by-default checkbox (single goal,
+  fully allocated) or per-goal distribution inputs (multiple); a multi-goal deficit
+  opens a split dialog; an automatic single-goal reduction is shown via a toast.
 - `/recurring-expenses` — template list with due-status indicator; CRUD modals.
 - `/budgets` — budget card grid (status + totals); "new budget" leads to the
   wizard (one unlocked budget at a time — enforced in UI and backend).
@@ -211,13 +222,12 @@ Specs live directly in `product/` (filename `NNN-slug.md`, lowest number =
 highest priority). Item 015 scoped six raw feature ideas into these; priority
 order reflects the maintainer's item 015 review (PR preview image first):
 
-- `070d–070e` **savings goals** (remaining parts: manual-balance reallocation →
-  progress/predictions). `070a` (backend foundation), `070b` (frontend goals
-  pages) and `070c` (budget-savings ↔ goal linking on lock/unlock) are **done** —
-  `070d` is the next gate. `070e` adds progress visualizations (charts are in
-  scope — see the non-goals note above), including surfacing the
-  `GoalAllocationChange` history (already fetchable via `GET /{id}/history`;
-  070b wired the hook but no UI yet).
+- `070e` **savings goals — progress/predictions** (the last part). `070a` (backend
+  foundation), `070b` (frontend goals pages), `070c` (budget-savings ↔ goal linking
+  on lock/unlock) and `070d` (manual-balance reallocation) are **done** — `070e` is
+  the next gate. `070e` adds progress visualizations (charts are in scope — see the
+  non-goals note above), including surfacing the `GoalAllocationChange` history
+  (already fetchable via `GET /{id}/history`; 070b wired the hook but no UI yet).
 
   Both the budget-detail savings modal **and** the create-budget wizard savings
   step expose the goal selector, so a saving can be linked to a goal either
@@ -231,6 +241,7 @@ order reflects the maintainer's item 015 review (PR preview image first):
 
 | Date | Item | Repos |
 |---|---|---|
+| 2026-06-25 | Manual balance changes reconcile goal allocations: auto single-goal deficit, multi-goal split (409), increase earmark (item 070d) | backend, frontend |
 | 2026-06-25 | Savings-goals budget linking: savings lines link to goals, earmark on lock / reverse on unlock (item 070c) | backend, frontend |
 | 2026-06-24 | Savings-goals frontend pages: list, detail, create/edit/assign/archive (item 070b) | frontend, backend (bookkeeping) |
 | 2026-06-24 | Savings-goals backend foundation: entities, allocation ledger + history, CRUD, archive (item 070a) | backend |

--- a/product/done/070d-savings-goals-balance-reallocation.md
+++ b/product/done/070d-savings-goals-balance-reallocation.md
@@ -147,3 +147,70 @@ makes no assumptions.
 - This is subtle, money-adjacent logic — derive the test list from the cases
   above before implementing, and keep all writes inside one transaction so a
   rejected multi-goal deficit leaves nothing changed.
+
+---
+
+## Completion notes
+
+**Completed:** 2026-06-25 — full-stack (balance-backend + balance-frontend; backend
+merges first).
+
+**API contract.** `POST /api/bank-accounts/{id}/balance` stays backward compatible.
+A new optional `reallocation` field is a list of `{ savingsGoalId, changeBy }` with
+**signed** amounts; the backend keys behaviour off the sign of the balance change:
+
+- **Increase** (`changeAmount > 0`): the new balance is applied first, then each
+  `changeBy` (must be ≥ 0) earmarks toward its goal. Requested additions may not
+  exceed the increase; the 070a invariant is enforced against the raised balance;
+  `requireActiveGoal` rejects archived/missing goals.
+- **Decrease** (`changeAmount < 0`): allocations are reconciled *before* the balance
+  is lowered, so a multi-goal split is never transiently over-allocated:
+  - within slack (`newBalance ≥ totalAllocated`) → no change;
+  - exactly one backing goal + deficit → that goal is auto-reduced by the deficit
+    (no `reallocation` needed), capped so it never falls below zero;
+  - two or more backing goals + deficit + no split → `409`
+    (`AllocationReallocationRequiredException`) carrying the conflict detail
+    (`accountId`, `accountName`, `newBalance`, `totalAllocated`, `requiredReduction`,
+    per-goal `currentAllocation`); with a split, each `changeBy` must be ≤ 0,
+    reference a backing goal, leave no allocation below zero, and sum exactly to the
+    deficit (else `400`).
+
+Every allocation change writes a `BALANCE_REALLOCATION` `GoalAllocationChange` ledger
+row (via the existing `applyAllocation`). The response gains an additive
+`allocationAdjustments: [{ savingsGoalId, goalName, changeAmount, resultingAmount }]`
+(empty when nothing changed). All writes run inside the existing `@Transactional`, so
+a rejected update (409/400) leaves nothing changed.
+
+**Frontend.** `UpdateBalanceModal` reads `useGoals()` to find the goals backing the
+account. On an **increase**: a single backing goal shows a checkbox ("also add the
+increase to ‹goal›?"), pre-checked iff the account was ≈100% allocated to that goal;
+multiple goals show optional per-goal distribution inputs (sum ≤ increase). On a
+**decrease** that 409s, `ReallocationSplitDialog` collects the split (must sum to the
+required reduction) and resubmits. Automatic single-goal reductions surface as a
+success toast. `ApiClientError` now carries the parsed response body so the UI can
+read the conflict detail.
+
+**Interpretation / deviations.**
+- Backend is "dumb but safe": it applies whatever valid split it is given and enforces
+  the invariant; the increase default-on/off cleverness lives only in the frontend.
+- Negative account balances with active allocations cannot satisfy the invariant (true
+  by definition); the single-goal auto path clamps the allocation at zero rather than
+  failing, matching the app's pre-existing "allow negative balance" behaviour for
+  goal-free accounts.
+- Predictions / visualisations remain out of scope (070e).
+
+**Tests.**
+- Backend: `BalanceReallocationIntegrationTest` (12) — slack / single-goal auto /
+  multi-goal 409 / valid split / invalid split (sum mismatch + below-zero) / increase
+  single / increase multi / increase exceeding increase / no-goals legacy /
+  negative-balance clamp.
+- Frontend: `UpdateBalanceReallocation.test.tsx` (5) — auto-reduction toast, 409 split
+  flow with resubmit, pre-checked vs unchecked earmark default, multi-goal distribution
+  inputs.
+
+**Verification.** Backend `./mvnw test` → `Tests run: 372, Failures: 0, Errors: 0`.
+Frontend `npm run lint` (0 errors) / `npx tsc --noEmit` (clean) / `npm test -- --run`
+(547 passing) / `npm run build` (success). Testcontainers ran against
+`postgres:15-alpine` pulled via the `mirror.gcr.io` Docker Hub mirror (the Docker Hub
+CDN host `production.cloudfront.docker.com` is blocked by this environment's egress
+policy) with `TESTCONTAINERS_RYUK_DISABLED=true`.

--- a/src/main/java/org/example/axelnyman/main/domain/abstracts/IDataService.java
+++ b/src/main/java/org/example/axelnyman/main/domain/abstracts/IDataService.java
@@ -162,6 +162,8 @@ public interface IDataService {
 
     List<GoalAllocation> getGoalAllocationsByGoalId(UUID savingsGoalId);
 
+    List<GoalAllocation> getGoalAllocationsByBankAccountId(UUID bankAccountId);
+
     BigDecimal sumAllocationsByBankAccountId(UUID bankAccountId);
 
     List<Object[]> sumAllocationsGroupedByBankAccount();

--- a/src/main/java/org/example/axelnyman/main/domain/dtos/BankAccountDtos.java
+++ b/src/main/java/org/example/axelnyman/main/domain/dtos/BankAccountDtos.java
@@ -1,5 +1,6 @@
 package org.example.axelnyman.main.domain.dtos;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -49,7 +50,22 @@ public class BankAccountDtos {
             LocalDate date,
 
             @Size(max = 500, message = "Comment must be less than 500 characters")
-            String comment
+            String comment,
+
+            // Optional (item 070d). Signed per-goal allocation changes resolving a
+            // balance update against this account's goal earmarks: negative reduces
+            // (splits a deficit), positive adds (earmarks an increase). Absent on the
+            // legacy request shape, which keeps its previous behaviour.
+            @Valid
+            List<ReallocationEntry> reallocation
+    ) {}
+
+    public record ReallocationEntry(
+            @NotNull(message = "Savings goal id is required")
+            UUID savingsGoalId,
+
+            @NotNull(message = "Change amount is required")
+            BigDecimal changeBy
     ) {}
 
     public record BalanceUpdateResponse(
@@ -58,7 +74,36 @@ public class BankAccountDtos {
             BigDecimal currentBalance,
             BigDecimal previousBalance,
             BigDecimal changeAmount,
-            LocalDate lastUpdated
+            LocalDate lastUpdated,
+            // Allocation earmarks adjusted as part of this balance update (item 070d):
+            // the auto single-goal deficit reduction, or the reductions/additions the
+            // caller requested. Empty when nothing was reallocated.
+            List<AllocationAdjustment> allocationAdjustments
+    ) {}
+
+    public record AllocationAdjustment(
+            UUID savingsGoalId,
+            String goalName,
+            BigDecimal changeAmount,
+            BigDecimal resultingAmount
+    ) {}
+
+    // Machine-readable 409 body when a decrease over-allocates an account backed by
+    // two or more goals and the caller supplied no split to resolve it (item 070d).
+    public record ReallocationConflictResponse(
+            String error,
+            UUID accountId,
+            String accountName,
+            BigDecimal newBalance,
+            BigDecimal totalAllocated,
+            BigDecimal requiredReduction,
+            List<ReallocationConflictGoal> goals
+    ) {}
+
+    public record ReallocationConflictGoal(
+            UUID savingsGoalId,
+            String goalName,
+            BigDecimal currentAllocation
     ) {}
 
     public record UpdateBankAccountRequest(

--- a/src/main/java/org/example/axelnyman/main/domain/services/DomainService.java
+++ b/src/main/java/org/example/axelnyman/main/domain/services/DomainService.java
@@ -38,6 +38,7 @@ import org.example.axelnyman.main.domain.model.TodoList;
 import org.example.axelnyman.main.domain.model.TransferPlan;
 import org.example.axelnyman.main.domain.utils.TransferCalculationUtils;
 import org.example.axelnyman.main.shared.exceptions.AccountLinkedToBudgetException;
+import org.example.axelnyman.main.shared.exceptions.AllocationReallocationRequiredException;
 import org.example.axelnyman.main.shared.exceptions.BackdatedBalanceUpdateException;
 import org.example.axelnyman.main.shared.exceptions.BankAccountNotFoundException;
 import org.example.axelnyman.main.shared.exceptions.BudgetAlreadyLockedException;
@@ -67,6 +68,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -187,40 +189,200 @@ public class DomainService implements IDomainService {
             );
         }
 
-        // Store previous balance
         BigDecimal previousBalance = account.getCurrentBalance();
-
-        // Calculate change amount (new - previous)
         BigDecimal changeAmount = request.newBalance().subtract(previousBalance);
 
-        // Update account's current balance
-        account.setCurrentBalance(request.newBalance());
+        // Reconcile the change against any savings-goal earmarks on this account
+        // (item 070d). All allocation writes and the balance write happen in this
+        // single transaction, so a rejected reallocation leaves nothing changed.
+        List<GoalAllocation> allocations = dataService.getGoalAllocationsByBankAccountId(id);
+        List<AllocationAdjustment> adjustments;
 
-        // Save updated account
-        BankAccount updatedAccount = dataService.saveBankAccount(account);
+        if (changeAmount.signum() >= 0) {
+            // Increase (or no change): raise the balance first, then earmark some/all
+            // of the increase toward goals if requested — validated against the
+            // already-raised balance so the invariant (allocations <= balance) holds.
+            persistBalanceChange(account, request, changeAmount);
+            adjustments = hasReallocation(request)
+                    ? applyIncreaseReallocation(account, allocations, changeAmount, request.reallocation())
+                    : List.of();
+        } else {
+            // Decrease: reconcile allocations before lowering the balance, so each
+            // reduction is checked against the still-valid higher balance and the
+            // account is never transiently over-allocated.
+            adjustments = reconcileDeficit(account, allocations, request);
+            persistBalanceChange(account, request, changeAmount);
+        }
 
-        // Create balance history entry with MANUAL source - use explicit changeDate
-        BalanceHistory historyEntry = new BalanceHistory(
-                updatedAccount.getId(),
-                request.newBalance(),
-                changeAmount,
-                request.comment(),
-                BalanceHistorySource.MANUAL,
-                null,  // budgetId is null for manual updates
-                request.date()  // explicit changeDate from request
-        );
-
-        dataService.saveBalanceHistory(historyEntry);
-
-        // Return response with previous and new balance info
         return new BalanceUpdateResponse(
-                updatedAccount.getId(),
-                updatedAccount.getName(),
-                updatedAccount.getCurrentBalance(),
+                account.getId(),
+                account.getName(),
+                account.getCurrentBalance(),
                 previousBalance,
                 changeAmount,
-                request.date()
+                request.date(),
+                adjustments
         );
+    }
+
+    private boolean hasReallocation(UpdateBalanceRequest request) {
+        return request.reallocation() != null && !request.reallocation().isEmpty();
+    }
+
+    private void persistBalanceChange(BankAccount account, UpdateBalanceRequest request, BigDecimal changeAmount) {
+        account.setCurrentBalance(request.newBalance());
+        dataService.saveBankAccount(account);
+        dataService.saveBalanceHistory(new BalanceHistory(
+                account.getId(), request.newBalance(), changeAmount,
+                request.comment(), BalanceHistorySource.MANUAL, null, request.date()));
+    }
+
+    /**
+     * Decrease path: when the new balance no longer covers the account's total
+     * earmarks, bring allocations back under the balance. Within slack does
+     * nothing; a single backing goal is auto-reduced by the deficit; two or more
+     * goals require an explicit split (a 409 conflict otherwise). A supplied split
+     * must use non-positive amounts summing exactly to the deficit, leaving no
+     * allocation below zero.
+     */
+    private List<AllocationAdjustment> reconcileDeficit(BankAccount account,
+            List<GoalAllocation> allocations, UpdateBalanceRequest request) {
+        if (allocations.isEmpty()) {
+            if (hasReallocation(request)) {
+                throw new IllegalArgumentException("Reallocation references goals that do not back this account");
+            }
+            return List.of();
+        }
+
+        BigDecimal totalAllocated = allocations.stream()
+                .map(GoalAllocation::getAmount).reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal deficit = totalAllocated.subtract(request.newBalance());
+
+        if (deficit.signum() <= 0) {
+            if (hasReallocation(request)) {
+                throw new IllegalArgumentException("No goal reallocation is required for this balance change");
+            }
+            return List.of();
+        }
+
+        if (hasReallocation(request)) {
+            return applyDeficitSplit(account, allocations, deficit, request.reallocation());
+        }
+
+        if (allocations.size() == 1) {
+            // Cap the reduction at the allocation amount so it never goes below zero
+            // (a negative new balance would otherwise produce a deficit > allocation).
+            GoalAllocation only = allocations.get(0);
+            return List.of(reduceAllocation(account, only, deficit.min(only.getAmount())));
+        }
+
+        throw new AllocationReallocationRequiredException(
+                buildConflict(account, request.newBalance(), totalAllocated, deficit, allocations));
+    }
+
+    private List<AllocationAdjustment> applyDeficitSplit(BankAccount account, List<GoalAllocation> allocations,
+            BigDecimal deficit, List<ReallocationEntry> entries) {
+        requireNoDuplicates(entries);
+        Map<UUID, GoalAllocation> byGoal = allocations.stream()
+                .collect(Collectors.toMap(GoalAllocation::getSavingsGoalId, a -> a));
+
+        BigDecimal totalReduction = BigDecimal.ZERO;
+        for (ReallocationEntry entry : entries) {
+            if (entry.changeBy().signum() > 0) {
+                throw new IllegalArgumentException(
+                        "Reallocation for a balance decrease must use non-positive amounts");
+            }
+            GoalAllocation allocation = byGoal.get(entry.savingsGoalId());
+            if (allocation == null) {
+                throw new IllegalArgumentException(
+                        "Reallocation references a goal that does not back this account: " + entry.savingsGoalId());
+            }
+            if (allocation.getAmount().add(entry.changeBy()).signum() < 0) {
+                throw new IllegalArgumentException("Reallocation would drive a goal allocation below zero");
+            }
+            totalReduction = totalReduction.add(entry.changeBy().negate());
+        }
+        if (totalReduction.compareTo(deficit) != 0) {
+            throw new IllegalArgumentException(
+                    "Reallocation reductions must sum to the required reduction of " + deficit.toPlainString());
+        }
+
+        List<AllocationAdjustment> adjustments = new ArrayList<>();
+        for (ReallocationEntry entry : entries) {
+            if (entry.changeBy().signum() == 0) {
+                continue;
+            }
+            adjustments.add(reduceAllocation(account, byGoal.get(entry.savingsGoalId()), entry.changeBy().negate()));
+        }
+        return adjustments;
+    }
+
+    /**
+     * Increase path: earmark requested amounts toward goals. Additions must be
+     * non-negative and sum to no more than the increase; each named goal must be
+     * active. {@link #applyAllocation} enforces the per-account invariant against
+     * the already-raised balance.
+     */
+    private List<AllocationAdjustment> applyIncreaseReallocation(BankAccount account, List<GoalAllocation> allocations,
+            BigDecimal increase, List<ReallocationEntry> entries) {
+        requireNoDuplicates(entries);
+        Map<UUID, BigDecimal> currentByGoal = allocations.stream()
+                .collect(Collectors.toMap(GoalAllocation::getSavingsGoalId, GoalAllocation::getAmount));
+
+        BigDecimal totalAddition = BigDecimal.ZERO;
+        for (ReallocationEntry entry : entries) {
+            if (entry.changeBy().signum() < 0) {
+                throw new IllegalArgumentException(
+                        "Reallocation for a balance increase must use non-negative amounts");
+            }
+            totalAddition = totalAddition.add(entry.changeBy());
+        }
+        if (totalAddition.compareTo(increase) > 0) {
+            throw new IllegalArgumentException(
+                    "Reallocation additions may not exceed the balance increase of " + increase.toPlainString());
+        }
+
+        List<AllocationAdjustment> adjustments = new ArrayList<>();
+        for (ReallocationEntry entry : entries) {
+            if (entry.changeBy().signum() == 0) {
+                continue;
+            }
+            SavingsGoal goal = requireActiveGoal(entry.savingsGoalId());
+            BigDecimal resulting = currentByGoal.getOrDefault(goal.getId(), BigDecimal.ZERO).add(entry.changeBy());
+            applyAllocation(goal.getId(), account, resulting, GoalAllocationChangeSource.BALANCE_REALLOCATION);
+            adjustments.add(new AllocationAdjustment(goal.getId(), goal.getName(), entry.changeBy(), resulting));
+        }
+        return adjustments;
+    }
+
+    private AllocationAdjustment reduceAllocation(BankAccount account, GoalAllocation allocation, BigDecimal reduceBy) {
+        BigDecimal resulting = allocation.getAmount().subtract(reduceBy);
+        applyAllocation(allocation.getSavingsGoalId(), account, resulting,
+                GoalAllocationChangeSource.BALANCE_REALLOCATION);
+        return new AllocationAdjustment(allocation.getSavingsGoalId(), goalName(allocation.getSavingsGoalId()),
+                reduceBy.negate(), resulting);
+    }
+
+    private ReallocationConflictResponse buildConflict(BankAccount account, BigDecimal newBalance,
+            BigDecimal totalAllocated, BigDecimal deficit, List<GoalAllocation> allocations) {
+        List<ReallocationConflictGoal> goals = allocations.stream()
+                .map(a -> new ReallocationConflictGoal(
+                        a.getSavingsGoalId(), goalName(a.getSavingsGoalId()), a.getAmount()))
+                .toList();
+        return new ReallocationConflictResponse(
+                "Balance decrease leaves the account over-allocated across multiple goals; a split is required",
+                account.getId(), account.getName(), newBalance, totalAllocated, deficit, goals);
+    }
+
+    private void requireNoDuplicates(List<ReallocationEntry> entries) {
+        long distinct = entries.stream().map(ReallocationEntry::savingsGoalId).distinct().count();
+        if (distinct != entries.size()) {
+            throw new IllegalArgumentException("Reallocation lists the same goal more than once");
+        }
+    }
+
+    private String goalName(UUID goalId) {
+        return dataService.getSavingsGoalById(goalId).map(SavingsGoal::getName).orElse(null);
     }
 
     @Override

--- a/src/main/java/org/example/axelnyman/main/infrastructure/data/context/GoalAllocationRepository.java
+++ b/src/main/java/org/example/axelnyman/main/infrastructure/data/context/GoalAllocationRepository.java
@@ -16,6 +16,8 @@ public interface GoalAllocationRepository extends JpaRepository<GoalAllocation, 
 
     List<GoalAllocation> findAllBySavingsGoalId(UUID savingsGoalId);
 
+    List<GoalAllocation> findAllByBankAccountId(UUID bankAccountId);
+
     Optional<GoalAllocation> findBySavingsGoalIdAndBankAccountId(UUID savingsGoalId, UUID bankAccountId);
 
     @Query("SELECT COALESCE(SUM(ga.amount), 0) FROM GoalAllocation ga WHERE ga.bankAccountId = :bankAccountId")

--- a/src/main/java/org/example/axelnyman/main/infrastructure/data/services/DataService.java
+++ b/src/main/java/org/example/axelnyman/main/infrastructure/data/services/DataService.java
@@ -402,6 +402,11 @@ public class DataService implements IDataService {
     }
 
     @Override
+    public java.util.List<GoalAllocation> getGoalAllocationsByBankAccountId(java.util.UUID bankAccountId) {
+        return goalAllocationRepository.findAllByBankAccountId(bankAccountId);
+    }
+
+    @Override
     public java.math.BigDecimal sumAllocationsByBankAccountId(java.util.UUID bankAccountId) {
         return goalAllocationRepository.sumAmountByBankAccountId(bankAccountId);
     }

--- a/src/main/java/org/example/axelnyman/main/shared/exceptions/AllocationReallocationRequiredException.java
+++ b/src/main/java/org/example/axelnyman/main/shared/exceptions/AllocationReallocationRequiredException.java
@@ -1,0 +1,24 @@
+package org.example.axelnyman.main.shared.exceptions;
+
+import org.example.axelnyman.main.domain.dtos.BankAccountDtos.ReallocationConflictResponse;
+
+/**
+ * Raised when a manual balance decrease leaves an account over-allocated and the
+ * account backs two or more savings goals, so the split of the required reduction
+ * is ambiguous. Carries a machine-readable {@link ReallocationConflictResponse}
+ * (affected goals, current allocations, required reduction) so the frontend can
+ * prompt the user to choose how to split it. Mapped to HTTP 409.
+ */
+public class AllocationReallocationRequiredException extends RuntimeException {
+
+    private final transient ReallocationConflictResponse detail;
+
+    public AllocationReallocationRequiredException(ReallocationConflictResponse detail) {
+        super(detail.error());
+        this.detail = detail;
+    }
+
+    public ReallocationConflictResponse getDetail() {
+        return detail;
+    }
+}

--- a/src/main/java/org/example/axelnyman/main/shared/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/axelnyman/main/shared/exceptions/GlobalExceptionHandler.java
@@ -227,6 +227,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
     }
 
+    @ExceptionHandler(AllocationReallocationRequiredException.class)
+    public ResponseEntity<Object> handleAllocationReallocationRequiredException(
+            AllocationReallocationRequiredException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(ex.getDetail());
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException ex) {
         Map<String, String> errorResponse = new HashMap<>();

--- a/src/test/java/org/example/axelnyman/main/integration/BalanceReallocationIntegrationTest.java
+++ b/src/test/java/org/example/axelnyman/main/integration/BalanceReallocationIntegrationTest.java
@@ -1,0 +1,421 @@
+package org.example.axelnyman.main.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.axelnyman.main.domain.dtos.BankAccountDtos.CreateBankAccountRequest;
+import org.example.axelnyman.main.domain.dtos.SavingsGoalDtos.AllocateRequest;
+import org.example.axelnyman.main.domain.dtos.SavingsGoalDtos.CreateSavingsGoalRequest;
+import org.example.axelnyman.main.infrastructure.data.context.BalanceHistoryRepository;
+import org.example.axelnyman.main.infrastructure.data.context.BankAccountRepository;
+import org.example.axelnyman.main.infrastructure.data.context.GoalAllocationChangeRepository;
+import org.example.axelnyman.main.infrastructure.data.context.GoalAllocationRepository;
+import org.example.axelnyman.main.infrastructure.data.context.SavingsGoalRepository;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Integration tests for manual balance updates that interact with savings-goal
+ * allocations (item 070d).
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Testcontainers
+public class BalanceReallocationIntegrationTest {
+
+    @Container
+    @SuppressWarnings("resource")
+    static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgreSQLContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", postgreSQLContainer::getUsername);
+        registry.add("spring.datasource.password", postgreSQLContainer::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    }
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private SavingsGoalRepository savingsGoalRepository;
+
+    @Autowired
+    private GoalAllocationRepository goalAllocationRepository;
+
+    @Autowired
+    private GoalAllocationChangeRepository goalAllocationChangeRepository;
+
+    @Autowired
+    private BankAccountRepository bankAccountRepository;
+
+    @Autowired
+    private BalanceHistoryRepository balanceHistoryRepository;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+
+        goalAllocationChangeRepository.deleteAll();
+        goalAllocationRepository.deleteAll();
+        savingsGoalRepository.deleteAll();
+        balanceHistoryRepository.deleteAll();
+        bankAccountRepository.deleteAll();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (postgreSQLContainer != null && postgreSQLContainer.isRunning()) {
+            postgreSQLContainer.stop();
+        }
+    }
+
+    // ---------- helpers ----------
+
+    private UUID createAccount(String name, String balance) throws Exception {
+        String response = mockMvc.perform(post("/api/bank-accounts")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                        new CreateBankAccountRequest(name, null, new BigDecimal(balance)))))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return UUID.fromString(objectMapper.readTree(response).get("id").asText());
+    }
+
+    private UUID createGoal(String name) throws Exception {
+        String response = mockMvc.perform(post("/api/savings-goals")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                        new CreateSavingsGoalRequest(name, null, null, null))))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return UUID.fromString(objectMapper.readTree(response).get("id").asText());
+    }
+
+    private void allocate(UUID goalId, UUID accountId, String amount) throws Exception {
+        mockMvc.perform(post("/api/savings-goals/" + goalId + "/allocations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new AllocateRequest(accountId, new BigDecimal(amount)))))
+                .andExpect(status().isOk());
+    }
+
+    private record Entry(UUID savingsGoalId, String changeBy) {}
+
+    private Entry entry(UUID goalId, String changeBy) {
+        return new Entry(goalId, changeBy);
+    }
+
+    private ResultActions updateBalance(UUID accountId, String newBalance, Entry... reallocation) throws Exception {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("newBalance", new BigDecimal(newBalance));
+        body.put("date", LocalDate.now().toString());
+        body.put("comment", "manual correction");
+        if (reallocation.length > 0) {
+            List<Map<String, Object>> entries = new ArrayList<>();
+            for (Entry e : reallocation) {
+                Map<String, Object> m = new LinkedHashMap<>();
+                m.put("savingsGoalId", e.savingsGoalId());
+                m.put("changeBy", new BigDecimal(e.changeBy()));
+                entries.add(m);
+            }
+            body.put("reallocation", entries);
+        }
+        return mockMvc.perform(post("/api/bank-accounts/" + accountId + "/balance")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)));
+    }
+
+    private BigDecimal goalTotalAllocated(UUID goalId) throws Exception {
+        String response = mockMvc.perform(get("/api/savings-goals/" + goalId))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return new BigDecimal(objectMapper.readTree(response).get("totalAllocated").asText());
+    }
+
+    private String latestHistorySource(UUID goalId) throws Exception {
+        String response = mockMvc.perform(get("/api/savings-goals/" + goalId + "/history"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("changes").get(0).get("source").asText();
+    }
+
+    // ---------- decrease: within slack ----------
+
+    @Test
+    void shouldNotChangeAllocationsWhenDecreaseStaysWithinSlack() throws Exception {
+        UUID account = createAccount("Checking", "1000.00");
+        UUID goal = createGoal("Buffer");
+        allocate(goal, account, "500.00");
+
+        updateBalance(account, "900.00")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.currentBalance", is(900.00)))
+                .andExpect(jsonPath("$.allocationAdjustments", hasSize(0)));
+
+        assertThat(goalTotalAllocated(goal)).isEqualByComparingTo("500.00");
+        // No reallocation row was written (only the original MANUAL allocation change).
+        assertThat(latestHistorySource(goal)).isEqualTo("MANUAL");
+    }
+
+    // ---------- decrease: single-goal deficit (auto) ----------
+
+    @Test
+    void shouldAutoReduceSingleGoalAllocationOnDeficit() throws Exception {
+        UUID account = createAccount("Checking", "1000.00");
+        UUID goal = createGoal("Buffer");
+        allocate(goal, account, "800.00");
+
+        updateBalance(account, "600.00")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.currentBalance", is(600.00)))
+                .andExpect(jsonPath("$.allocationAdjustments", hasSize(1)))
+                .andExpect(jsonPath("$.allocationAdjustments[0].savingsGoalId", is(goal.toString())))
+                .andExpect(jsonPath("$.allocationAdjustments[0].changeAmount", is(-200.00)))
+                .andExpect(jsonPath("$.allocationAdjustments[0].resultingAmount", is(600.00)));
+
+        assertThat(goalTotalAllocated(goal)).isEqualByComparingTo("600.00");
+        assertThat(latestHistorySource(goal)).isEqualTo("BALANCE_REALLOCATION");
+        // Invariant: allocations (600) == balance (600), fully backed.
+        assertAccountAllocated(account, "600.00", "0");
+    }
+
+    // ---------- decrease: multi-goal deficit ----------
+
+    @Test
+    void shouldRejectMultiGoalDeficitWithoutSplit() throws Exception {
+        UUID account = createAccount("Checking", "1000.00");
+        UUID goalA = createGoal("House");
+        UUID goalB = createGoal("Car");
+        allocate(goalA, account, "400.00");
+        allocate(goalB, account, "400.00");
+
+        updateBalance(account, "600.00")
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error", not(emptyOrNullString())))
+                .andExpect(jsonPath("$.accountId", is(account.toString())))
+                .andExpect(jsonPath("$.newBalance", is(600.00)))
+                .andExpect(jsonPath("$.totalAllocated", is(800.00)))
+                .andExpect(jsonPath("$.requiredReduction", is(200.00)))
+                .andExpect(jsonPath("$.goals", hasSize(2)))
+                .andExpect(jsonPath("$.goals[*].savingsGoalId",
+                        containsInAnyOrder(goalA.toString(), goalB.toString())));
+
+        // Nothing changed: balance and both allocations intact (no partial writes).
+        assertAccountBalance(account, "1000.00");
+        assertThat(goalTotalAllocated(goalA)).isEqualByComparingTo("400.00");
+        assertThat(goalTotalAllocated(goalB)).isEqualByComparingTo("400.00");
+    }
+
+    @Test
+    void shouldApplyMultiGoalDeficitSplitWhenProvided() throws Exception {
+        UUID account = createAccount("Checking", "1000.00");
+        UUID goalA = createGoal("House");
+        UUID goalB = createGoal("Car");
+        allocate(goalA, account, "400.00");
+        allocate(goalB, account, "400.00");
+
+        updateBalance(account, "600.00", entry(goalA, "-150.00"), entry(goalB, "-50.00"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allocationAdjustments", hasSize(2)));
+
+        assertThat(goalTotalAllocated(goalA)).isEqualByComparingTo("250.00");
+        assertThat(goalTotalAllocated(goalB)).isEqualByComparingTo("350.00");
+        // Invariant: 250 + 350 == 600 balance.
+        assertAccountAllocated(account, "600.00", "0");
+        assertThat(latestHistorySource(goalA)).isEqualTo("BALANCE_REALLOCATION");
+        assertThat(latestHistorySource(goalB)).isEqualTo("BALANCE_REALLOCATION");
+    }
+
+    @Test
+    void shouldRejectDeficitSplitNotSummingToDeficit() throws Exception {
+        UUID account = createAccount("Checking", "1000.00");
+        UUID goalA = createGoal("House");
+        UUID goalB = createGoal("Car");
+        allocate(goalA, account, "400.00");
+        allocate(goalB, account, "400.00");
+
+        // Deficit is 200 but reductions sum to 150.
+        updateBalance(account, "600.00", entry(goalA, "-100.00"), entry(goalB, "-50.00"))
+                .andExpect(status().isBadRequest());
+
+        assertAccountBalance(account, "1000.00");
+        assertThat(goalTotalAllocated(goalA)).isEqualByComparingTo("400.00");
+        assertThat(goalTotalAllocated(goalB)).isEqualByComparingTo("400.00");
+    }
+
+    @Test
+    void shouldRejectDeficitSplitDrivingAllocationBelowZero() throws Exception {
+        UUID account = createAccount("Checking", "1000.00");
+        UUID goalA = createGoal("House");
+        UUID goalB = createGoal("Car");
+        allocate(goalA, account, "100.00");
+        allocate(goalB, account, "700.00");
+
+        // Deficit is 200; reductions sum to 200 but goalA only holds 100.
+        updateBalance(account, "600.00", entry(goalA, "-150.00"), entry(goalB, "-50.00"))
+                .andExpect(status().isBadRequest());
+
+        assertAccountBalance(account, "1000.00");
+        assertThat(goalTotalAllocated(goalA)).isEqualByComparingTo("100.00");
+        assertThat(goalTotalAllocated(goalB)).isEqualByComparingTo("700.00");
+    }
+
+    @Test
+    void shouldClampSingleGoalReductionToZeroWhenBalanceGoesNegative() throws Exception {
+        UUID account = createAccount("Checking", "1000.00");
+        UUID goal = createGoal("Buffer");
+        allocate(goal, account, "400.00");
+
+        updateBalance(account, "-50.00")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.currentBalance", is(-50.00)))
+                .andExpect(jsonPath("$.allocationAdjustments", hasSize(1)))
+                .andExpect(jsonPath("$.allocationAdjustments[0].resultingAmount", is(0.00)));
+
+        assertThat(goalTotalAllocated(goal)).isEqualByComparingTo("0");
+    }
+
+    // ---------- increase ----------
+
+    @Test
+    void shouldNotChangeAllocationsWhenIncreaseWithoutReallocation() throws Exception {
+        UUID account = createAccount("Checking", "1000.00");
+        UUID goal = createGoal("Buffer");
+        allocate(goal, account, "500.00");
+
+        updateBalance(account, "1200.00")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allocationAdjustments", hasSize(0)));
+
+        assertThat(goalTotalAllocated(goal)).isEqualByComparingTo("500.00");
+        assertAccountAllocated(account, "500.00", "700.00");
+    }
+
+    @Test
+    void shouldEarmarkIncreaseToSingleGoalWhenRequested() throws Exception {
+        UUID account = createAccount("Savings", "1000.00");
+        UUID goal = createGoal("House deposit");
+        allocate(goal, account, "1000.00"); // fully allocated
+
+        updateBalance(account, "1200.00", entry(goal, "200.00"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allocationAdjustments", hasSize(1)))
+                .andExpect(jsonPath("$.allocationAdjustments[0].changeAmount", is(200.00)))
+                .andExpect(jsonPath("$.allocationAdjustments[0].resultingAmount", is(1200.00)));
+
+        assertThat(goalTotalAllocated(goal)).isEqualByComparingTo("1200.00");
+        assertAccountAllocated(account, "1200.00", "0");
+        assertThat(latestHistorySource(goal)).isEqualTo("BALANCE_REALLOCATION");
+    }
+
+    @Test
+    void shouldDistributeIncreaseAcrossMultipleGoalsWhenRequested() throws Exception {
+        UUID account = createAccount("Savings", "1000.00");
+        UUID goalA = createGoal("House");
+        UUID goalB = createGoal("Car");
+        allocate(goalA, account, "300.00");
+        allocate(goalB, account, "200.00");
+
+        updateBalance(account, "1300.00", entry(goalA, "100.00"), entry(goalB, "50.00"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.allocationAdjustments", hasSize(2)));
+
+        assertThat(goalTotalAllocated(goalA)).isEqualByComparingTo("400.00");
+        assertThat(goalTotalAllocated(goalB)).isEqualByComparingTo("250.00");
+        assertAccountAllocated(account, "650.00", "650.00");
+    }
+
+    @Test
+    void shouldRejectIncreaseReallocationExceedingIncrease() throws Exception {
+        UUID account = createAccount("Savings", "1000.00");
+        UUID goal = createGoal("House");
+        allocate(goal, account, "500.00");
+
+        // Increase is only 100 but the request earmarks 200.
+        updateBalance(account, "1100.00", entry(goal, "200.00"))
+                .andExpect(status().isBadRequest());
+
+        // Whole transaction rolled back: balance and allocation unchanged.
+        assertAccountBalance(account, "1000.00");
+        assertThat(goalTotalAllocated(goal)).isEqualByComparingTo("500.00");
+    }
+
+    // ---------- legacy compatibility ----------
+
+    @Test
+    void shouldReturnEmptyAdjustmentsWhenAccountHasNoGoals() throws Exception {
+        UUID account = createAccount("Checking", "1000.00");
+
+        updateBalance(account, "750.00")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.currentBalance", is(750.00)))
+                .andExpect(jsonPath("$.allocationAdjustments", hasSize(0)));
+    }
+
+    // ---------- assertion helpers ----------
+
+    private void assertAccountAllocated(UUID accountId, String allocated, String unallocated) throws Exception {
+        String response = mockMvc.perform(get("/api/bank-accounts"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        var accounts = objectMapper.readTree(response).get("accounts");
+        for (var acc : accounts) {
+            if (acc.get("id").asText().equals(accountId.toString())) {
+                assertThat(new BigDecimal(acc.get("allocatedAmount").asText())).isEqualByComparingTo(allocated);
+                assertThat(new BigDecimal(acc.get("unallocatedAmount").asText())).isEqualByComparingTo(unallocated);
+                return;
+            }
+        }
+        throw new AssertionError("Account not found: " + accountId);
+    }
+
+    private void assertAccountBalance(UUID accountId, String balance) throws Exception {
+        String response = mockMvc.perform(get("/api/bank-accounts"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        var accounts = objectMapper.readTree(response).get("accounts");
+        for (var acc : accounts) {
+            if (acc.get("id").asText().equals(accountId.toString())) {
+                assertThat(new BigDecimal(acc.get("currentBalance").asText())).isEqualByComparingTo(balance);
+                return;
+            }
+        }
+        throw new AssertionError("Account not found: " + accountId);
+    }
+}


### PR DESCRIPTION
## What & why

Manual balance corrections (`POST /api/bank-accounts/{id}/balance`) now keep savings-goal earmarks truthful instead of letting them drift from reality. A balance **drop** can over-allocate an account; a balance **rise** is often money that belongs to a goal. This makes the allocation ledger react to the size and direction of the change — while never forcing the user.

**Backlog item:** 070d-savings-goals-balance-reallocation

Backend half of a full-stack item. **Merge this first** — the live frontend keeps working against it, and the sibling frontend PR depends on the new response/conflict shape.
Frontend PR: axel-nyman/balance-frontend#26.

## API contract (backward compatible)

The legacy request shape (no `reallocation`) still works. A new optional `reallocation` field is a list of `{ savingsGoalId, changeBy }` with **signed** amounts. Behaviour keys off the sign of the balance change:

- **Increase** (`changeAmount > 0`): the new balance is applied first, then each `changeBy` (≥ 0) earmarks toward its goal. Requested additions may not exceed the increase; the 070a invariant is enforced against the raised balance; archived/missing goals are rejected.
- **Decrease** (`changeAmount < 0`): allocations are reconciled *before* the balance is lowered, so a split is never transiently over-allocated:
  - within slack (`newBalance ≥ totalAllocated`) → no change;
  - one backing goal + deficit → auto-reduced by the deficit (no `reallocation` needed), capped so it never goes below zero;
  - 2+ backing goals + deficit + no split → **409** (`AllocationReallocationRequiredException`) with machine-readable conflict detail (`accountId`, `accountName`, `newBalance`, `totalAllocated`, `requiredReduction`, per-goal `currentAllocation`);
  - with a split → each `changeBy` ≤ 0, must reference a backing goal, leave no allocation below zero, and sum exactly to the deficit (else **400**).

Every allocation change writes a `BALANCE_REALLOCATION` `GoalAllocationChange` row. The response gains an additive `allocationAdjustments: [{ savingsGoalId, goalName, changeAmount, resultingAmount }]` (empty when nothing changed). All writes run inside the existing `@Transactional`, so a rejected update leaves nothing changed.

The backend stays "dumb but safe": it applies whatever valid split it's given and enforces the invariant. The increase default-on/off cleverness lives in the frontend.

## Tests

`BalanceReallocationIntegrationTest` (12 Testcontainers tests): decrease within slack · single-goal auto-reduce (+ ledger row) · multi-goal 409 (no partial writes) · valid multi-goal split · invalid split (sum mismatch) · split driving an allocation below zero · increase single-goal earmark · increase multi-goal distribution · increase exceeding the increase · no-goals legacy path · negative-balance clamp. Existing `BankAccountIntegrationTest` (incl. `shouldAllowNegativeBalance`) still green.

## Verification

```
./mvnw test  →  Tests run: 372, Failures: 0, Errors: 0  •  BUILD SUCCESS
```

Testcontainers ran against `postgres:15-alpine` pulled via the `mirror.gcr.io` Docker Hub mirror — the Docker Hub CDN host `production.cloudfront.docker.com` is **blocked by this environment's egress policy (403)** — with `TESTCONTAINERS_RYUK_DISABLED=true`. Pure environment workaround; no code or config changed for it.

## Bookkeeping

Spec moved to `product/done/070d-…md` with completion notes; `STATE.md` updated (monthly routine, API surface, frontend pages, recently completed, open backlog).

## Assumptions / limitations

- Negative account balances with active allocations cannot satisfy the invariant (true by definition); the single-goal auto path clamps the allocation at zero rather than failing, matching the app's pre-existing "allow negative balance" behaviour for goal-free accounts.
- Predictions/visualisations remain out of scope (070e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UDbG25xTCSU4V45WYSibG