### PR TITLE
docs: mark item 070e (savings-goals progress/projections) done

### DIFF
--- a/product/STATE.md
+++ b/product/STATE.md
@@ -6,7 +6,7 @@
 > `CHANGELOG.md` (generated — never hand-edit), and `.claude/thoughts/` in
 > both repos for engineering research and plans.
 
-**Last updated:** 2026-06-25 (item 070c — budget savings ↔ goal linking on lock)
+**Last updated:** 2026-06-25 (item 070e — savings-goals progress/history chart & projections)
 
 ## What Balance is
 
@@ -160,10 +160,16 @@ tables; V6 added the nullable `budget_savings.savings_goal_id` FK).
   bar, backing accounts, completed badge); "new goal" opens a create modal with
   an optional initial allocation seeded from an account's unallocated money
   (item 070b).
-- `/goals/:id` — goal summary + progress, per-account allocation breakdown, and
-  edit / assign-money (capped at unallocated) / archive actions. Archive offers
-  the `releaseToBalance` choice (free the earmark, or also spend it and reduce
-  backing balances). Archived goals render read-only (item 070b).
+- `/goals/:id` — goal summary + progress (allocated/target/remaining), per-account
+  allocation breakdown, and edit / assign-money (capped at unallocated) / archive
+  actions. A "Progress over time" card (item 070e) shows a dependency-free
+  inline-SVG chart of allocated-over-time (reconstructed from the
+  `GET /{id}/history` ledger), a velocity-based projected completion date (or a
+  "not enough history yet" fallback), and — for goals with an end date — the
+  required monthly contribution vs. current pace (ahead/behind). Forward-looking
+  text is shown for ACTIVE goals only. Archive offers the `releaseToBalance`
+  choice (free the earmark, or also spend it and reduce backing balances).
+  Archived goals render read-only (item 070b).
 
 ## Conventions that matter
 
@@ -211,13 +217,11 @@ Specs live directly in `product/` (filename `NNN-slug.md`, lowest number =
 highest priority). Item 015 scoped six raw feature ideas into these; priority
 order reflects the maintainer's item 015 review (PR preview image first):
 
-- `070d–070e` **savings goals** (remaining parts: manual-balance reallocation →
-  progress/predictions). `070a` (backend foundation), `070b` (frontend goals
-  pages) and `070c` (budget-savings ↔ goal linking on lock/unlock) are **done** —
-  `070d` is the next gate. `070e` adds progress visualizations (charts are in
-  scope — see the non-goals note above), including surfacing the
-  `GoalAllocationChange` history (already fetchable via `GET /{id}/history`;
-  070b wired the hook but no UI yet).
+- `070d` **savings goals** — manual-balance reallocation. `070a` (backend
+  foundation), `070b` (frontend goals pages), `070c` (budget-savings ↔ goal
+  linking on lock/unlock) and `070e` (progress/history chart + projections on
+  the goal detail page) are **done**; `070d` is in-flight (open PRs) and is the
+  last remaining slice. After 070d the savings-goals feature is complete.
 
   Both the budget-detail savings modal **and** the create-budget wizard savings
   step expose the goal selector, so a saving can be linked to a goal either
@@ -231,6 +235,7 @@ order reflects the maintainer's item 015 review (PR preview image first):
 
 | Date | Item | Repos |
 |---|---|---|
+| 2026-06-25 | Savings-goals progress: goal detail history chart, velocity projection & end-date required-contribution (item 070e) | frontend, backend (bookkeeping) |
 | 2026-06-25 | Savings-goals budget linking: savings lines link to goals, earmark on lock / reverse on unlock (item 070c) | backend, frontend |
 | 2026-06-24 | Savings-goals frontend pages: list, detail, create/edit/assign/archive (item 070b) | frontend, backend (bookkeeping) |
 | 2026-06-24 | Savings-goals backend foundation: entities, allocation ledger + history, CRUD, archive (item 070a) | backend |

--- a/product/done/070e-savings-goals-predictions.md
+++ b/product/done/070e-savings-goals-predictions.md
@@ -88,3 +88,52 @@ follow-up rather than expanding this item.
 
 - This is the lowest-priority slice of the savings-goals feature; the feature is
   fully usable after 070a–070d.
+
+## Completion notes
+
+- **Date:** 2026-06-25
+- **PRs:** balance-frontend (feature) + balance-backend (this `docs:` bookkeeping).
+  Frontend-only item — no backend code changed. Independent of the in-flight
+  070d PRs (070d touches the update-balance flow; 070e only reads the goal
+  detail page + the existing `GET /api/savings-goals/{id}/history` endpoint).
+- **Where it lives:** goal detail page (`/goals/:id`). New pure functions in
+  `src/lib/goal-projection.ts` (unit-tested in `goal-projection.test.ts`), a
+  dependency-free inline-SVG `GoalHistoryChart`, and a `GoalInsights` section
+  that composes the chart + projection + end-date assessment.
+
+### Interpretation decisions
+
+- **Velocity source.** The `GoalAllocationChange` ledger stores a per-account
+  `resultingAmount`, not the goal total, so velocity is reconstructed by
+  cumulatively summing the **signed `changeAmount`** deltas in chronological
+  order (`buildAllocationSeries`) — robust to multi-account goals. The ledger
+  is returned newest-first, so the series is sorted ascending first.
+- **"Enough history".** A pace is only inferred from **≥2 allocation changes
+  spanning ≥14 days** with a positive net trend (`MIN_HISTORY_DAYS`); otherwise
+  the UI shows "Not enough history yet" instead of a misleading guess. Velocity
+  = net growth between the first and last ledger points ÷ months between them.
+- **Projection anchor.** The projected completion date is `now + remaining /
+  velocity` (months converted at 30.4375 days/month). `now` is injected into the
+  pure functions for deterministic tests.
+- **Chart baseline.** The history chart prepends a synthetic `(goal.createdAt,
+  0 kr)` point so the line reads from zero; this is visual only and is excluded
+  from the velocity calculation (which uses real ledger events).
+- **Forward-looking text** (projection + required-contribution) is shown only
+  for **ACTIVE** goals; archived goals still render the history chart.
+- **No charting dependency.** A single goal-history view doesn't justify a new
+  runtime dependency (recharts etc.); rendered as plain `viewBox`-scaled SVG,
+  consistent with the minimal-diff guardrail.
+
+### Deviations / cut
+
+- The progress card shows **remaining-to-target**; the existing % already sits
+  beside the bar via `GoalProgress`, so it was not duplicated in the new stat.
+- No backend change was needed — the 070a `/history` endpoint was sufficient,
+  as the spec anticipated.
+
+### Verification
+
+- `npm run lint` → 0 errors (pre-existing warnings only)
+- `npx tsc --noEmit` → clean; `tsc -b && vite build` → success
+- `npm test -- --run` → 61 files, 566 tests passing (20 new pure-function unit
+  tests + 4 new goal-detail component tests)


### PR DESCRIPTION
## What & why

Product bookkeeping for the frontend-only item **070e** (savings-goals progress / history chart / projections). No backend code changes.

**Backlog item:** 070e-savings-goals-predictions

Sibling (feature) PR: axel-nyman/balance-frontend#27. Frontend-only — no merge-order constraint; this docs PR can merge whenever.

## Changes

- Move `product/070e-savings-goals-predictions.md` → `product/done/`, appending `## Completion notes` (date, interpretation decisions, deviations, verification).
- `STATE.md`:
  - `/goals/:id` page description now covers the "Progress over time" card (SVG history chart, velocity projection, end-date required-contribution).
  - Open backlog: only **070d** remains in-flight; 070e moved out.
  - Recently-completed table + last-updated line.

## Why no backend change

The spec anticipated this: the 070a `GET /api/savings-goals/{id}/history` ledger endpoint was sufficient. Velocity is derived on the frontend by cumulatively summing the signed `changeAmount` deltas (the ledger's `resultingAmount` is per-account, not the goal total).

## Verification

Docs-only; no code touched. Frontend verification (lint / tsc / build / 566 tests) is in the sibling PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AETFJtpfTT3os88WQYDEBb

---
_Generated by [Claude Code](https://claude.ai/code/session_01AETFJtpfTT3os88WQYDEBb)_