### PR TITLE
docs: refill backlog with specs 080, 090, 100

### DIFF
--- a/product/080-edit-budget-month-year.md
+++ b/product/080-edit-budget-month-year.md
@@ -1,0 +1,79 @@
+# Edit a budget's month/year after creation
+
+- **ID:** 080-edit-budget-month-year
+- **Scope:** full-stack
+- **Size:** M (about a day)
+
+## Why
+
+If the couple picks the wrong month in the wizard (easy to do near a
+month boundary), there is no way to fix it: month/year is fixed at creation.
+The only recourse today is to delete the whole budget — losing every income,
+expense, and savings line — and rebuild it from scratch. Letting an UNLOCKED
+budget's month/year be corrected in place removes a sharp, data-losing edge
+from the monthly routine.
+
+## What
+
+Add the ability to change an UNLOCKED budget's month and year after creation,
+keeping all its line items. On `/budgets/:id` (UNLOCKED only) expose an
+"edit month" action that opens a modal to pick a new month/year, validated the
+same way the wizard's month step is. LOCKED budgets stay immutable. The change
+must respect the existing invariants: month/year is unique among non-deleted
+budgets, and only the most recent budget may be the unlocked working draft.
+
+## Acceptance criteria
+
+- [ ] `PUT /api/budgets/{id}` updates month and/or year of an **UNLOCKED**
+      budget and returns the updated `BudgetResponse`; all income/expense/
+      savings lines are preserved unchanged
+- [ ] Attempting to edit a **LOCKED** budget returns a domain error (no change)
+- [ ] Changing to a (month, year) that already belongs to another non-deleted
+      budget returns the same duplicate error used by budget creation (409),
+      with no change persisted
+- [ ] The "one unlocked budget at a time / only the latest budget is the
+      working draft" rule is not weakened — if editing the month/year would
+      violate the temporal invariant the app enforces at creation, it is
+      rejected with a clear error (interpretation recorded in the PR)
+- [ ] No-op edits (same month/year) succeed idempotently
+- [ ] Frontend: an "edit month" action on `/budgets/:id` for UNLOCKED budgets
+      opens a modal (RHF + Zod) mirroring the wizard's month step; LOCKED
+      budgets show no such action
+- [ ] Backend integration tests cover success, locked-rejection, duplicate
+      (409), and no-op; frontend component tests cover shown/hidden-by-status
+      and the happy-path save
+
+## API changes (backend)
+
+New `PUT /api/budgets/{id}` accepting `{ "month": int, "year": int }`
+(both 1–12 / sane year range, validated in the DTO). Returns the standard
+`BudgetResponse`. Purely additive — the currently deployed frontend never
+calls it, so existing behavior is unchanged. The endpoint must **not** touch
+status, `lockedAt`, line items, balances, todos, or allocations — it only
+edits the month/year fields. STATE.md's API-surface note ("There is no
+`PUT /api/budgets/{id}` … not yet specced") is resolved by this item.
+
+## UI notes (frontend)
+
+Reuse the wizard month-step component/validation (`src/components/wizard/`),
+the existing modal + React Hook Form + Zod pattern, and the budget mutation
+hooks in `src/hooks/` (add a `useUpdateBudget`/`useEditBudgetMonth` mutation
+that invalidates the budget detail + list query keys). sv-SE month names.
+
+## Out of scope
+
+- Editing month/year of a LOCKED budget (must unlock first)
+- Bulk re-dating or merging budgets
+- Any change to line items, balances, or the lock/unlock flow
+
+## Notes
+
+- Backend: `BudgetController` (`api/endpoints/BudgetController.java`) has
+  GET/DELETE/lock/unlock on `/{id}` but no PUT. The `Budget` entity already
+  has `setMonth`/`setYear` and a unique constraint on
+  `(month, year, deleted_at)` (`domain/model/Budget.java:12`), so the duplicate
+  path is enforced at the DB level too — surface it as the existing
+  duplicate-budget domain exception, not a raw constraint error.
+- Verify how creation enforces "latest budget only / one unlocked at a time"
+  (DomainService) and apply the *same* rule here; record the exact
+  interpretation in the PR. This is the main design risk — keep it minimal.

--- a/product/090-reconcile-backlog-dir-drift.md
+++ b/product/090-reconcile-backlog-dir-drift.md
@@ -1,0 +1,56 @@
+# Reconcile the `product/backlog/` directory doc drift
+
+- **ID:** 090-reconcile-backlog-dir-drift
+- **Scope:** backend (docs only)
+- **Size:** S (≤ half a day)
+
+## Why
+
+`README.md`, both repos' `CLAUDE.md`, and `ROUTINE_PROMPT.md` all say backlog
+specs live in `product/backlog/`, but in reality they sit **flat** in
+`product/` (only `done/` is a real subdirectory). STATE.md documents this as
+known drift and tells readers to "treat the backlog as the `NNN-*.md` files in
+`product/`." Every fresh agent has to discover this mismatch by running `ls`
+and finding `backlog/` does not exist (this run did). Making docs and reality
+agree removes a recurring papercut from the one workflow every routine depends
+on.
+
+## What
+
+Pick one source of truth and make everything match it. **Recommended:** create
+the `product/backlog/` subdirectory and move the open `NNN-*.md` specs into it,
+because four separate docs already describe that layout — moving the files is
+less churn than rewriting all of them, and it matches the system's original
+design (`done/` is already a subdir). Whichever direction is chosen, after this
+item there must be **zero** remaining references to a layout that doesn't exist.
+
+## Acceptance criteria
+
+- [ ] After the change, the documented backlog location and the actual on-disk
+      location agree — verified by following each doc literally
+- [ ] `STATE.md`'s "Doc drift" bullet under "Known quirks & debt" is removed (or
+      rewritten to reflect the resolved state); the "Open backlog" section's
+      path description matches reality
+- [ ] `README.md`, `balance-backend/CLAUDE.md`, `balance-frontend/CLAUDE.md`,
+      and `ROUTINE_PROMPT.md` all reference the same, correct path
+- [ ] If the subdir approach is taken: the `NNN-*.md` specs (including the new
+      080/100 from this batch) are `git mv`d into `product/backlog/`, and the
+      "lowest-numbered spec in `product/backlog/`" pick rule now works literally
+- [ ] No spec **content** is changed and no code changes — this is a docs/layout
+      reconciliation only
+
+## Out of scope
+
+- Renaming or renumbering any spec
+- Touching `done/`, `todo/`, or `TEMPLATE.md` content
+- Any application code or backlog **prioritization** changes
+
+## Notes
+
+- Cross-repo: the frontend `CLAUDE.md` "Product Workflow" section points at
+  these same paths, so the frontend gets a small sibling `docs:` change too
+  (one PR per repo, per the routine).
+- Touch only docs and the spec file locations; do not alter
+  `.github/workflows/` or any build config.
+- Whoever implements this should also confirm `ROUTINE_PROMPT.md`'s step 3 and
+  the "Empty backlog" section read correctly against the chosen layout.

--- a/product/100-transfer-algorithm-e2e-tests.md
+++ b/product/100-transfer-algorithm-e2e-tests.md
@@ -1,0 +1,62 @@
+# Harden the lock-time transfer algorithm with correctness E2E tests
+
+- **ID:** 100-transfer-algorithm-e2e-tests
+- **Scope:** backend (tests only)
+- **Size:** M (about a day)
+
+## Why
+
+Locking a budget computes the minimal set of inter-account transfers to cover
+each account's planned net position (the greedy `TransferCalculationUtils`) and
+then *applies those transfers to real account balances*. This is the most
+safety-critical write in the app against the couple's real money. It has unit
+coverage, but no end-to-end test proves that the transfers a real lock produces
+are self-consistent, balance-preserving, and free of nonsense edges
+(self-transfers, cycles). Promoting sprint-5 Story 32 into a focused E2E suite
+turns the data-safety mandate ("correctness beats feature count") into
+regression protection before any future change touches the lock flow.
+
+## What
+
+Add a `@SpringBootTest` + Testcontainers E2E test class that drives the real
+`POST budget → add lines → PUT /lock` path and asserts the transfer plan and
+the resulting balances are correct, covering the Story 32 cases. No production
+code changes are expected; if a test surfaces a genuine bug, stop and report it
+in the PR rather than silently "fixing" the algorithm in the same change.
+
+## Acceptance criteria
+
+- [ ] **No self-transfers:** no generated TRANSFER todo item has the same
+      from-account and to-account
+- [ ] **No trivial cycles:** the transfer set does not contain a pair that
+      cancels (A→B and B→A for the same amount); the greedy result is acyclic
+- [ ] **Conservation:** total money moved out equals total moved in; every
+      account's post-lock balance equals its pre-lock balance plus its planned
+      net position (income to it − expenses/savings from it)
+- [ ] **Transfer-count minimality:** for a known fixture the number of transfers
+      equals the expected minimum (n accounts with non-zero net → ≤ n−1
+      transfers); a documented hub/all-deficit fixture is asserted exactly
+- [ ] **Edge fixtures:** all-deficit accounts and a dominant-hub pattern (from
+      Story 32) each produce a valid, conservation-respecting plan
+- [ ] Tests run green in the existing `./mvnw test` suite with no new runtime
+      dependencies; assertions use `BigDecimal` comparisons (`compareTo`), never
+      `equals`
+
+## Out of scope
+
+- Changing `TransferCalculationUtils` or the lock/unlock flow (tests only) —
+  unless a test proves a real defect, which is reported, not fixed here
+- The other nine sprint-5 stories (promote separately if wanted)
+- Any frontend change
+
+## Notes
+
+- Source under test: `domain/utils/TransferCalculationUtils.java` (existing unit
+  test: `src/test/java/.../domain/utils/TransferCalculationUtilsTest.java`) and
+  the lock path in the budget `DomainService`.
+- Original spec: `todo/backlog/sprint-5/32-transfer-algorithm-e2e-tests.md`
+  (5 tests). Reuse the integration-test harness/fixtures other budget
+  integration tests already use (`BudgetIntegrationTest`).
+- Move `todo/backlog/sprint-5/32-*.md` to `todo/done/` as part of this item's
+  bookkeeping (in addition to the usual `product/` → `done/` move and STATE.md
+  update), since it promotes that sprint-5 story.

--- a/product/STATE.md
+++ b/product/STATE.md
@@ -6,7 +6,7 @@
 > `CHANGELOG.md` (generated — never hand-edit), and `.claude/thoughts/` in
 > both repos for engineering research and plans.
 
-**Last updated:** 2026-06-25 (item 070d — manual balance changes reconcile goal allocations)
+**Last updated:** 2026-06-26 (backlog refilled — proposed specs 080, 090, 100)
 
 ## What Balance is
 
@@ -227,11 +227,16 @@ tables; V6 added the nullable `budget_savings.savings_goal_id` FK).
 Specs live directly in `product/` (filename `NNN-slug.md`, lowest number =
 highest priority).
 
-_Empty._ The savings-goals feature is complete: `070a` (backend foundation),
-`070b` (frontend goals pages), `070c` (budget-savings ↔ goal linking on
-lock/unlock), `070e` (progress/history chart + projections on the goal detail
-page) and `070d` (manual-balance reallocation) are all **done**. No specs are
-currently waiting in `product/`.
+The savings-goals feature is complete (`070a`–`070e`, all **done**). Three new
+specs were proposed on 2026-06-26 to refill the empty backlog (grounded in
+documented debt, routine friction, and the sprint-5 E2E stories); the
+maintainer prioritizes/approves them by merging the proposal PR:
+
+| Item | What | Scope | Size |
+|---|---|---|---|
+| `080-edit-budget-month-year` | Edit an UNLOCKED budget's month/year in place (`PUT /api/budgets/{id}`) instead of delete-and-rebuild | full-stack | M |
+| `090-reconcile-backlog-dir-drift` | Make docs and reality agree on the `product/backlog/` location (resolve the known drift) | backend (docs) | S |
+| `100-transfer-algorithm-e2e-tests` | Promote sprint-5 Story 32: correctness E2E tests for the lock-time transfer algorithm | backend (tests) | M |
 
 ## Recently completed
 


### PR DESCRIPTION
## What & why

The backlog was **empty** after the savings-goals epic (`070a`–`070e`) all merged, and both repos have only release-please PRs open. Per the routine's **Empty backlog** procedure, this PR proposes three TEMPLATE-shaped specs and does **not** implement any of them — the maintainer prioritizes/approves by merging.

Each proposal is grounded in something concrete already documented in `STATE.md` or `todo/`:

| Item | What | Scope | Size | Grounded in |
|---|---|---|---|---|
| `080-edit-budget-month-year` | Edit an **UNLOCKED** budget's month/year in place via `PUT /api/budgets/{id}` instead of delete-and-rebuild | full-stack | M | STATE.md API-surface note: *"There is no `PUT /api/budgets/{id}` … a possible future item; not yet specced"* — and real routine friction (wrong month ⇒ lose every line item) |
| `090-reconcile-backlog-dir-drift` | Make the docs and the on-disk layout agree on where backlog specs live (`product/backlog/` vs. flat `product/`) | backend (docs) | S | STATE.md "Known quirks & debt → Doc drift" — every fresh agent rediscovers this by hand |
| `100-transfer-algorithm-e2e-tests` | Promote sprint-5 **Story 32**: correctness E2E tests for the safety-critical lock-time transfer algorithm (no self-transfers, no cycles, conservation, minimality) | backend (tests) | M | `todo/backlog/sprint-5/32-…` + the data-safety mandate |

These are intentionally diverse — one feature, one docs cleanup, one test-hardening — so the maintainer can pick by appetite. Numbered with gaps (080/090/100) per the workflow; `080` is lowest-priority-number so a later run picks it first.

## Spec details / interpretation flags

- **080** flags the main design risk explicitly: the `Budget` entity already has a unique constraint on `(month, year, deleted_at)` and the creation flow enforces a "latest budget / one unlocked at a time" rule — the spec tells the implementer to reuse the existing duplicate-budget domain exception and apply the *same* temporal rule, and to record the exact interpretation in its PR. Purely additive endpoint; the deployed frontend never calls it.
- **090** recommends (but doesn't mandate) creating the `product/backlog/` subdir, since four separate docs already describe that layout — less churn than rewriting them all. Resolving this also makes `ROUTINE_PROMPT.md` step 3's "lowest-numbered spec in `product/backlog/`" literally correct.
- **100** is tests-only: if a test surfaces a real defect it is **reported in that PR, not silently fixed** in the same change, to keep the diff honest.

## Bookkeeping

`STATE.md` updated: "Last updated" header + the "Open backlog" section now lists the three queued specs (replacing *"Empty"*).

## Verification

Docs-only change — no code touched, so no build/test run applies. `git diff --cached --stat`: 3 new spec files + `STATE.md` (208 insertions).

Backlog item: n/a (this is the empty-backlog proposal PR; it creates backlog items rather than completing one)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXv6o9bZEg3xgwNfzyR34c)_